### PR TITLE
Add flag to disable automatic spdlog fetching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(MALLOY_FEATURE_CLIENT "Whether to build the client"     ON)
 option(MALLOY_FEATURE_SERVER "Whether to build the server"     ON)
 option(MALLOY_FEATURE_HTML   "Whether to enable HTML features" ON)
 option(MALLOY_FEATURE_TLS    "Whether to enable TLS features"  OFF)
+option(MALLOY_INCLUDE_SPDLOG "Whether to automatically fetch spdlog" ON)
 
 # Set dependencies accordingly
 if (MALLOY_FEATURE_TLS)

--- a/lib/malloy/CMakeLists.txt
+++ b/lib/malloy/CMakeLists.txt
@@ -54,6 +54,10 @@ target_sources(
         utils.hpp
 )
 
+if (NOT MALLOY_INCLUDE_SPDLOG)
+    find_package(spdlog REQUIRED)
+endif()
+
 target_link_libraries(
     ${TARGET_OBJS}
     PUBLIC

--- a/lib/malloy/external.cmake
+++ b/lib/malloy/external.cmake
@@ -12,12 +12,14 @@ find_package(
 ########################################################################################################################
 # spdlog
 ########################################################################################################################
-FetchContent_Declare(
-    spdlog
-    GIT_REPOSITORY https://github.com/gabime/spdlog
-    GIT_TAG        v1.8.3
-)
-FetchContent_MakeAvailable(spdlog)
+if (MALLOY_INCLUDE_SPDLOG)
+    FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog
+        GIT_TAG        v1.8.3
+    )
+    FetchContent_MakeAvailable(spdlog)
+endif()
 
 ########################################################################################################################
 # OpenSSL


### PR DESCRIPTION
This adds an option to disable the automatic download of spdlog and use `find_package` instead. It caused issues when using a package manager (conan) since there were some conflicts in the package name (`spdlog::spdlog` was already declared as an alias and it was a mess). 

The flag is on by default in order to preserve current behaviour.