### PR TITLE
Fix windows build due to invalid flags

### DIFF
--- a/lib/malloy/CMakeLists.txt
+++ b/lib/malloy/CMakeLists.txt
@@ -75,5 +75,5 @@ target_compile_options(
     ${TARGET_OBJS}
     PRIVATE
     $<$<BOOL:${MSYS_GCC}>:-Wa,-mbig-obj>
-    $<$<BOOL:${MSVC}>:-O3>
+    $<$<BOOL:${MSYS_GCC}>:-O3>
 )

--- a/lib/malloy/CMakeLists.txt
+++ b/lib/malloy/CMakeLists.txt
@@ -66,8 +66,14 @@ target_link_libraries(
         $<$<BOOL:${MALLOY_FEATURE_TLS}>:OpenSSL::SSL>
 )
 
+if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND WIN32 AND NOT MINGW)
+    set(MSYS_GCC 1)
+    message(STATUS "Assuming compiler is GCC on MSYS2")
+endif()
+
 target_compile_options(
     ${TARGET_OBJS}
     PRIVATE
-        $<$<NOT:${WIN32}>:-O3>
+    $<$<BOOL:${MSYS_GCC}>:-Wa,-mbig-obj>
+    $<$<BOOL:${MSVC}>:-O3>
 )

--- a/lib/malloy/CMakeLists.txt
+++ b/lib/malloy/CMakeLists.txt
@@ -69,6 +69,5 @@ target_link_libraries(
 target_compile_options(
     ${TARGET_OBJS}
     PRIVATE
-        $<$<BOOL:${WIN32}>:-Wa,-mbig-obj>
-        $<$<BOOL:${WIN32}>:-O3>
+        $<$<NOT:${WIN32}>:-O3>
 )


### PR DESCRIPTION
The windows build fails currently due to the "/Wa,-mbig-obj" compile flags. I'm not very familier with MSVC but I couldn't find either of those flags anywhere and `cl.exe` doesn't like them. Removing them seems not to cause any issues (so far) but I'm scared I might've messed with some magic incantation :p.