### PR TITLE
fix: Build with boost headers outside system include dirs

### DIFF
--- a/lib/malloy/CMakeLists.txt
+++ b/lib/malloy/CMakeLists.txt
@@ -73,3 +73,10 @@ target_compile_options(
         $<$<BOOL:${WIN32}>:-Wa,-mbig-obj>
         $<$<BOOL:${WIN32}>:-O3>
 )
+
+target_compile_definitions(
+    ${TARGET_OBJS}
+    PRIVATE 
+        $<$<BOOL:${WIN32}>:BOOST_DATE_TIME_NO_LIB>
+
+    )

--- a/lib/malloy/CMakeLists.txt
+++ b/lib/malloy/CMakeLists.txt
@@ -58,6 +58,7 @@ target_link_libraries(
     ${TARGET_OBJS}
     PUBLIC
         spdlog::spdlog
+        Boost::headers
     PRIVATE
         $<$<BOOL:${WIN32}>:wsock32>
         $<$<BOOL:${WIN32}>:ws2_32>


### PR DESCRIPTION
Currently there is a `find_package` call for boost but its never used. This is fine in the case where boost has been installed to the system or similar, but it doesn't work for builds that rely on the boost package files adding the include paths (e.g. conan). Adding `boost::headers` (or `boost::boost`) to the public linked libraries of malloy-objs fixes this but requires `BOOST_DATE_TIME_NO_LIB` to be added to the compile definitions on windows (otherwise you get a link error). 

This is the last of the modifications I made to get this library to build with conan + MSVC. I tested the build with fedora + system boost install so I don't _think_ it breaks existing setups.