### PR TITLE
feat: Responses with any body type for regex route

### DIFF
--- a/lib/malloy/client/controller.cpp
+++ b/lib/malloy/client/controller.cpp
@@ -23,7 +23,7 @@ using namespace malloy::client;
 template<class Connection>
 [[nodiscard]]
 static
-std::future<malloy::http::response>
+std::future<malloy::http::response<>>
 http_request_(malloy::http::request req, std::shared_ptr<Connection> connection)
 {
     return std::async(
@@ -36,7 +36,7 @@ http_request_(malloy::http::request req, std::shared_ptr<Connection> connection)
             conn->run(
                 std::to_string(req.port()).c_str(),
                 req,
-                [&ret_resp, &done](malloy::http::response&& resp){
+                [&ret_resp, &done](malloy::http::response<>&& resp){
                     ret_resp = std::move(resp);
                     done = true;
                 }
@@ -64,7 +64,7 @@ http_request_(malloy::http::request req, std::shared_ptr<Connection> connection)
     }
 #endif // MALLOY_FEATURE_TLS
 
-std::future<malloy::http::response>
+std::future<malloy::http::response<>>
 controller::http_request(malloy::http::request req)
 {
     // Create connection
@@ -78,7 +78,7 @@ controller::http_request(malloy::http::request req)
 }
 
 #if MALLOY_FEATURE_TLS
-    std::future<malloy::http::response>
+    std::future<malloy::http::response<>>
     controller::https_request(malloy::http::request req)
     {
         // Check whether TLS context was initialized

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -47,7 +47,7 @@ namespace malloy::client
          * @return The corresponding response.
          */
         [[nodiscard]]
-        std::future<http::response>
+        std::future<http::response<>>
         http_request(http::request req);
 
         #if MALLOY_FEATURE_TLS
@@ -59,7 +59,7 @@ namespace malloy::client
              * @return The corresponding response.
              */
             [[nodiscard]]
-            std::future<http::response>
+            std::future<http::response<>>
             https_request(http::request req);
         #endif
 

--- a/lib/malloy/client/http/connection.hpp
+++ b/lib/malloy/client/http/connection.hpp
@@ -19,7 +19,7 @@ namespace malloy::client::http
     class connection
     {
     public:
-        using callback_t = std::function<void(malloy::http::response&&)>;
+        using callback_t = std::function<void(malloy::http::response<>&&)>;
 
         connection(std::shared_ptr<spdlog::logger> logger, boost::asio::io_context& io_ctx) :
             m_logger(std::move(logger)),
@@ -75,7 +75,7 @@ namespace malloy::client::http
         boost::asio::ip::tcp::resolver m_resolver;
         boost::beast::flat_buffer m_buffer; // (Must persist between reads)
         malloy::http::request m_req;
-        malloy::http::response m_resp;
+        malloy::http::response<> m_resp;
         callback_t m_cb;
 
         [[nodiscard]]

--- a/lib/malloy/http/generator.cpp
+++ b/lib/malloy/http/generator.cpp
@@ -4,14 +4,14 @@
 
 using namespace malloy::http;
 
-response generator::ok()
+response<> generator::ok()
 {
     response resp { status::ok };
 
     return resp;
 }
 
-response generator::redirect(const status code, const std::string_view location)
+response<> generator::redirect(const status code, const std::string_view location)
 {
     const int& icode = static_cast<int>(code);
     if (icode < 300 || icode >= 400)
@@ -24,7 +24,7 @@ response generator::redirect(const status code, const std::string_view location)
     return resp;
 }
 
-response generator::bad_request(std::string_view reason)
+response<> generator::bad_request(std::string_view reason)
 {
     response res(status::bad_request);
     res.set(field::content_type, "text/html");
@@ -34,7 +34,7 @@ response generator::bad_request(std::string_view reason)
     return res;
 }
 
-response generator::not_found(std::string_view resource)
+response<> generator::not_found(std::string_view resource)
 {
     response res(status::not_found);
     res.set(field::content_type, "text/html");
@@ -44,7 +44,7 @@ response generator::not_found(std::string_view resource)
     return res;
 }
 
-response generator::server_error(std::string_view what)
+response<> generator::server_error(std::string_view what)
 {
     response res(status::internal_server_error);
     res.set(field::content_type, "text/html");
@@ -54,12 +54,12 @@ response generator::server_error(std::string_view what)
     return res;
 }
 
-response generator::file(const request& req, const std::filesystem::path& storage_base_path)
+response<> generator::file(const request& req, const std::filesystem::path& storage_base_path)
 {
 	return file(storage_base_path, req.uri().resource_string());
 }
 
-response generator::file(const std::filesystem::path& storage_base_path, std::string_view rel_path)
+response<> generator::file(const std::filesystem::path& storage_base_path, std::string_view rel_path)
 {
     // Sanitize rel_path
     {

--- a/lib/malloy/http/generator.cpp
+++ b/lib/malloy/http/generator.cpp
@@ -54,12 +54,12 @@ response<> generator::server_error(std::string_view what)
     return res;
 }
 
-response<boost::beast::http::file_body> generator::file(const request& req, const std::filesystem::path& storage_base_path)
+auto generator::file(const request& req, const std::filesystem::path& storage_base_path) -> file_response
 {
 	return file(storage_base_path, req.uri().resource_string());
 }
 
-response<boost::beast::http::file_body> generator::file(const std::filesystem::path& storage_base_path, std::string_view rel_path)
+auto generator::file(const std::filesystem::path& storage_base_path, std::string_view rel_path) -> file_response
 {
     // Sanitize rel_path
     {

--- a/lib/malloy/http/generator.cpp
+++ b/lib/malloy/http/generator.cpp
@@ -54,12 +54,12 @@ response<> generator::server_error(std::string_view what)
     return res;
 }
 
-response<> generator::file(const request& req, const std::filesystem::path& storage_base_path)
+response<boost::beast::http::file_body> generator::file(const request& req, const std::filesystem::path& storage_base_path)
 {
 	return file(storage_base_path, req.uri().resource_string());
 }
 
-response<> generator::file(const std::filesystem::path& storage_base_path, std::string_view rel_path)
+response<boost::beast::http::file_body> generator::file(const std::filesystem::path& storage_base_path, std::string_view rel_path)
 {
     // Sanitize rel_path
     {

--- a/lib/malloy/http/generator.hpp
+++ b/lib/malloy/http/generator.hpp
@@ -4,10 +4,10 @@
 #include <string_view>
 
 #include "types.hpp"
+#include "response.hpp"
 
 namespace malloy::http
 {
-    class response;
     class request;
 
     /**
@@ -39,7 +39,7 @@ namespace malloy::http
          * Construct a 200 response.
          */
         [[nodiscard]]
-        static response ok();
+        static response<> ok();
 
         /**
          * Construct a 3xx response.
@@ -49,7 +49,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response redirect(status code, std::string_view location);
+        static response<> redirect(status code, std::string_view location);
 
         /**
          * Construct a 400 error.
@@ -58,7 +58,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response bad_request(std::string_view reason);
+        static response<> bad_request(std::string_view reason);
 
         /**
          * Construct a 404 error.
@@ -67,7 +67,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response not_found(std::string_view resource);
+        static response<> not_found(std::string_view resource);
 
         /**
          * Construct a 500 error.
@@ -76,7 +76,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response server_error(std::string_view what);
+        static response<> server_error(std::string_view what);
 
         /**
          * Construct a file response.
@@ -86,7 +86,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response file(const request& req, const std::filesystem::path& storage_path);
+        static response<> file(const request& req, const std::filesystem::path& storage_path);
 
         /**
          * Construct a file response.
@@ -96,7 +96,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response file(const std::filesystem::path& storage_path, std::string_view rel_path);
+        static response<> file(const std::filesystem::path& storage_path, std::string_view rel_path);
     };
 
 }

--- a/lib/malloy/http/generator.hpp
+++ b/lib/malloy/http/generator.hpp
@@ -86,7 +86,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response<> file(const request& req, const std::filesystem::path& storage_path);
+        static response<boost::beast::http::file_body> file(const request& req, const std::filesystem::path& storage_path);
 
         /**
          * Construct a file response.
@@ -96,7 +96,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response<> file(const std::filesystem::path& storage_path, std::string_view rel_path);
+        static response<boost::beast::http::file_body> file(const std::filesystem::path& storage_path, std::string_view rel_path);
     };
 
 }

--- a/lib/malloy/http/generator.hpp
+++ b/lib/malloy/http/generator.hpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <string_view>
+#include <variant>
 
 #include "types.hpp"
 #include "response.hpp"
@@ -17,6 +18,7 @@ namespace malloy::http
      */
     class generator
     {
+        using file_response = std::variant<response<boost::beast::http::file_body>, response<boost::beast::http::string_body>>;
     public:
         /**
          * Default constructor.
@@ -86,7 +88,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response<boost::beast::http::file_body> file(const request& req, const std::filesystem::path& storage_path);
+        static auto file(const request& req, const std::filesystem::path& storage_path) -> file_response;
 
         /**
          * Construct a file response.
@@ -96,7 +98,7 @@ namespace malloy::http
          * @return The response.
          */
         [[nodiscard]]
-        static response<boost::beast::http::file_body> file(const std::filesystem::path& storage_path, std::string_view rel_path);
+        static auto file(const std::filesystem::path& storage_path, std::string_view rel_path) -> file_response;
     };
 
 }

--- a/lib/malloy/http/response.hpp
+++ b/lib/malloy/http/response.hpp
@@ -16,9 +16,12 @@ namespace malloy::http
     /**
      * The response type.
      */
+    template<typename Body = boost::beast::http::string_body, typename Fields = boost::beast::http::fields>
     class response :
-        public boost::beast::http::response<boost::beast::http::string_body>
+        public boost::beast::http::response<Body, Fields>
     {
+        using msg_t = boost::beast::http::response<Body, Fields>;
+
     public:
         /**
          * Default constructor.
@@ -32,7 +35,7 @@ namespace malloy::http
          */
         response(const status& status_)
         {
-            result(status_);
+            msg_t::result(status_);
         }
 
         /**
@@ -75,7 +78,7 @@ namespace malloy::http
          *
          * @param status The HTTP status code.
          */
-        void set_status(http::status status) { result(status); }
+        void set_status(http::status status) { msg_t::result(status); }
 
         /**
          * Retrieve the HTTP status.
@@ -83,7 +86,7 @@ namespace malloy::http
          * @return The HTTP status
          */
         [[nodiscard]]
-        http::status status() const { return result(); }
+        http::status status() const { return msg_t::result(); }
 
         /**
          * Adds a cookie.
@@ -92,7 +95,7 @@ namespace malloy::http
          */
         void add_cookie(const cookie& c)
         {
-            insert(boost::beast::http::field::set_cookie, c.to_string());
+            msg_t::insert(boost::beast::http::field::set_cookie, c.to_string());
         }
     };
 

--- a/lib/malloy/http/session/manager.cpp
+++ b/lib/malloy/http/session/manager.cpp
@@ -18,7 +18,7 @@ manager::manager(std::shared_ptr<storage> storage) :
         throw std::invalid_argument("no valid storage provided.");
 }
 
-std::shared_ptr<session> manager::start(const request& req, response& resp)
+std::shared_ptr<session> manager::start(const request& req, response<>& resp)
 {
     // Nothing to do if no storage was provided
     if (!m_storage)
@@ -54,7 +54,7 @@ std::shared_ptr<session> manager::start(const request& req, response& resp)
     return session;
 }
 
-void manager::destroy(const request& req, response& resp)
+void manager::destroy(const request& req, response<>& resp)
 {
     if (!m_storage)
         return;

--- a/lib/malloy/http/session/manager.hpp
+++ b/lib/malloy/http/session/manager.hpp
@@ -74,7 +74,7 @@ namespace malloy::http::sessions
          * @return The session.
          */
         [[nodiscard]]
-        std::shared_ptr<session> start(const request& req, response& resp);
+        std::shared_ptr<session> start(const request& req, response<>& resp);
 
         /**
          * Destroys an existing session.
@@ -82,7 +82,7 @@ namespace malloy::http::sessions
          * @param req The request.
          * @param resp The response.
          */
-        void destroy(const request& req, response& resp);
+        void destroy(const request& req, response<>& resp);
 
         /**
          * Destroys any sessions older than the specified max lifetime.

--- a/lib/malloy/http/session/manager.hpp
+++ b/lib/malloy/http/session/manager.hpp
@@ -7,10 +7,11 @@
 #include <mutex>
 #include <string>
 
+#include "malloy/http/response.hpp"
+
 namespace malloy::http
 {
     class request;
-    class response;
 }
 
 namespace malloy::http::sessions

--- a/lib/malloy/server/http/connection/connection.hpp
+++ b/lib/malloy/server/http/connection/connection.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include "malloy/server/routing/router.hpp"
+#include "malloy/http/request.hpp"
+#include "malloy/server/http/connection/connection_t.hpp"
+
 #include "malloy/server/websocket/connection/connection_plain.hpp"
 #if MALLOY_FEATURE_TLS
     #include "malloy/server/websocket/connection/connection_tls.hpp"
@@ -27,6 +29,7 @@ namespace spdlog
 namespace malloy::server::http
 {
 
+
     /**
      * An HTTP server connection.
      *
@@ -37,6 +40,17 @@ namespace malloy::server::http
     class connection
     {
     public:
+        class handler {
+        public:
+            using request = malloy::http::request;
+            using conn_t = const connection_t&;
+            using path = std::filesystem::path;
+
+            virtual void websocket(const path& root, request&& req, conn_t) = 0;
+            virtual void http(const path& root, request&& req, conn_t) = 0;
+            
+        
+        };
         /**
          * Session configuration structure.
          */
@@ -61,7 +75,7 @@ namespace malloy::server::http
         connection(
             std::shared_ptr<spdlog::logger> logger,
             boost::beast::flat_buffer buffer,
-            std::shared_ptr<malloy::server::router> router,
+            std::shared_ptr<handler> router,
             std::shared_ptr<const std::filesystem::path> http_doc_root
         ) :
             m_logger(std::move(logger)),
@@ -136,7 +150,7 @@ namespace malloy::server::http
     private:
         std::shared_ptr<spdlog::logger> m_logger;
         std::shared_ptr<const std::filesystem::path> m_doc_root;
-        std::shared_ptr<malloy::server::router> m_router;
+        std::shared_ptr<handler> m_router;
         std::shared_ptr<void> m_response;
 
         // The parser is stored in an optional container so we can
@@ -194,13 +208,13 @@ namespace malloy::server::http
                 ws_connection->run(req);
 
                 // Hand over to router
-                m_router->handle_request<true>(*m_doc_root, std::move(req), ws_connection);
+                m_router->websocket(*m_doc_root, std::move(req), ws_connection);
             }
 
             // This is an HTTP request
             else {
                 // Hand over to router
-                m_router->handle_request<false>(*m_doc_root, std::move(req), derived().shared_from_this());
+                m_router->http(*m_doc_root, std::move(req), derived().shared_from_this());
             }
         }
 

--- a/lib/malloy/server/http/connection/connection.hpp
+++ b/lib/malloy/server/http/connection/connection.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "malloy/http/request.hpp"
+#include "malloy/http/generator.hpp"
 #include "malloy/server/http/connection/connection_t.hpp"
 
 #include "malloy/server/websocket/connection/connection_plain.hpp"

--- a/lib/malloy/server/http/connection/connection_plain.hpp
+++ b/lib/malloy/server/http/connection/connection_plain.hpp
@@ -18,7 +18,7 @@ namespace malloy::server::http
             boost::asio::ip::tcp::socket&& socket,
             boost::beast::flat_buffer buffer,
             std::shared_ptr<const std::filesystem::path> doc_root,
-            std::shared_ptr<malloy::server::router> router
+            std::shared_ptr<handler> router
         ) :
             connection<connection_plain>(
                 std::move(logger),

--- a/lib/malloy/server/http/connection/connection_t.hpp
+++ b/lib/malloy/server/http/connection/connection_t.hpp
@@ -1,0 +1,37 @@
+
+#pragma once
+
+#include <variant>
+#include <memory>
+
+
+
+namespace malloy::server::http {
+class connection_plain;
+
+#if MALLOY_FEATURE_TLS
+
+class connection_tls;
+
+#endif
+}
+namespace malloy::server::websocket {
+class connection_plain;
+
+#if MALLOY_FEATURE_TLS 
+
+class connection_tls;
+
+#endif
+}
+namespace malloy::server::http {
+
+using connection_t = std::variant<
+    std::shared_ptr<connection_plain>,
+    std::shared_ptr<malloy::server::websocket::connection_plain>
+#if MALLOY_FEATURE_TLS 
+    ,std::shared_ptr<connection_tls>
+    ,std::shared_ptr<malloy::server::websocket::connection_tls>
+#endif 
+    >;
+}

--- a/lib/malloy/server/http/connection/connection_tls.hpp
+++ b/lib/malloy/server/http/connection/connection_tls.hpp
@@ -23,7 +23,7 @@ namespace malloy::server::http
             std::shared_ptr<boost::asio::ssl::context> ctx,
             boost::beast::flat_buffer buffer,
             std::shared_ptr<const std::filesystem::path> doc_root,
-            std::shared_ptr<malloy::server::router> router
+            std::shared_ptr<handler> router
         ) :
             connection<connection_tls>(
                 logger,

--- a/lib/malloy/server/routing/endpoint_http.hpp
+++ b/lib/malloy/server/routing/endpoint_http.hpp
@@ -55,7 +55,7 @@ namespace malloy::server
          */
         [[nodiscard]]
         virtual
-        handle_retr handle(const malloy::http::request& req, http::connection_t& conn) const = 0;
+        handle_retr handle(const malloy::http::request& req, const http::connection_t& conn) const = 0;
     };
 
 }

--- a/lib/malloy/server/routing/endpoint_http.hpp
+++ b/lib/malloy/server/routing/endpoint_http.hpp
@@ -14,12 +14,15 @@
 namespace malloy::server
 {
 
-    /**
+     /**
      * An HTTP endpoint.
      */
     struct endpoint_http :
         endpoint
     {
+        template<typename... Bodies>
+        using writer_t = std::function<void(const malloy::http::request&, std::variant<malloy::http::response<Bodies>...>&&, const http::connection_t&)>;
+
         using handle_retr = std::optional<malloy::http::response<boost::beast::http::string_body>>;
 
         malloy::http::method method = malloy::http::method::unknown;

--- a/lib/malloy/server/routing/endpoint_http.hpp
+++ b/lib/malloy/server/routing/endpoint_http.hpp
@@ -6,6 +6,11 @@
 #include "../../http/response.hpp"
 #include "../../http/types.hpp"
 
+#include "malloy/server/http/connection/connection_t.hpp"
+
+#include <optional>
+#include <functional>
+
 namespace malloy::server
 {
 
@@ -15,6 +20,7 @@ namespace malloy::server
     struct endpoint_http :
         endpoint
     {
+        using handle_retr = std::optional<malloy::http::response<boost::beast::http::string_body>>;
 
         malloy::http::method method = malloy::http::method::unknown;
 
@@ -49,7 +55,7 @@ namespace malloy::server
          */
         [[nodiscard]]
         virtual
-        malloy::http::response handle(const malloy::http::request& req) const = 0;
+        handle_retr handle(const malloy::http::request& req, http::connection_t& conn) const = 0;
     };
 
 }

--- a/lib/malloy/server/routing/endpoint_http_files.hpp
+++ b/lib/malloy/server/routing/endpoint_http_files.hpp
@@ -13,7 +13,7 @@ namespace malloy::server
     public:
         std::string resource_base;
         std::filesystem::path base_path;
-        writer_t<boost::beast::http::file_body> writer;
+        writer_t<boost::beast::http::file_body, boost::beast::http::string_body> writer;
 
         [[nodiscard]]
         bool matches(const malloy::http::request& req) const override

--- a/lib/malloy/server/routing/endpoint_http_files.hpp
+++ b/lib/malloy/server/routing/endpoint_http_files.hpp
@@ -13,6 +13,7 @@ namespace malloy::server
     public:
         std::string resource_base;
         std::filesystem::path base_path;
+        std::function<void(const malloy::http::request&, malloy::http::response<boost::beast::http::file_body>&&, http::connection_t&)> writer;
 
         [[nodiscard]]
         bool matches(const malloy::http::request& req) const override
@@ -21,16 +22,16 @@ namespace malloy::server
         }
 
         [[nodiscard]]
-        malloy::http::response handle(const malloy::http::request& req) const override
+        handle_retr handle(const malloy::http::request& req, http::connection_t& conn) const override
         {
             // Chop request resource path
             malloy::http::request req_clone{ req };
             req_clone.uri().chop_resource(resource_base);
 
             // Create response
-            auto resp = malloy::http::generator::file(req_clone, base_path);
+            writer(req, malloy::http::generator::file(req_clone, base_path), conn);
 
-            return resp;
+            return std::nullopt;
         }
 
     };

--- a/lib/malloy/server/routing/endpoint_http_files.hpp
+++ b/lib/malloy/server/routing/endpoint_http_files.hpp
@@ -13,7 +13,7 @@ namespace malloy::server
     public:
         std::string resource_base;
         std::filesystem::path base_path;
-        std::function<void(const malloy::http::request&, malloy::http::response<boost::beast::http::file_body>&&, const http::connection_t&)> writer;
+        writer_t<boost::beast::http::file_body> writer;
 
         [[nodiscard]]
         bool matches(const malloy::http::request& req) const override

--- a/lib/malloy/server/routing/endpoint_http_files.hpp
+++ b/lib/malloy/server/routing/endpoint_http_files.hpp
@@ -13,7 +13,7 @@ namespace malloy::server
     public:
         std::string resource_base;
         std::filesystem::path base_path;
-        std::function<void(const malloy::http::request&, malloy::http::response<boost::beast::http::file_body>&&, http::connection_t&)> writer;
+        std::function<void(const malloy::http::request&, malloy::http::response<boost::beast::http::file_body>&&, const http::connection_t&)> writer;
 
         [[nodiscard]]
         bool matches(const malloy::http::request& req) const override
@@ -22,7 +22,7 @@ namespace malloy::server
         }
 
         [[nodiscard]]
-        handle_retr handle(const malloy::http::request& req, http::connection_t& conn) const override
+        handle_retr handle(const malloy::http::request& req, const http::connection_t& conn) const override
         {
             // Chop request resource path
             malloy::http::request req_clone{ req };

--- a/lib/malloy/server/routing/endpoint_http_redirect.hpp
+++ b/lib/malloy/server/routing/endpoint_http_redirect.hpp
@@ -13,6 +13,7 @@ namespace malloy::server
         std::string resource_old;
         std::string resource_new;
 
+
         [[nodiscard]]
         bool matches(const malloy::http::request& req) const override
         {
@@ -20,7 +21,7 @@ namespace malloy::server
         }
 
         [[nodiscard]]
-        malloy::http::response handle(const malloy::http::request& req) const override
+        handle_retr handle(const malloy::http::request& req, http::connection_t&) const override
         {
             return malloy::http::generator::redirect(status, resource_new);
         }

--- a/lib/malloy/server/routing/endpoint_http_redirect.hpp
+++ b/lib/malloy/server/routing/endpoint_http_redirect.hpp
@@ -9,7 +9,7 @@ namespace malloy::server
         endpoint_http
     {
     public:
-        http::status status;
+        malloy::http::status status;
         std::string resource_old;
         std::string resource_new;
 

--- a/lib/malloy/server/routing/endpoint_http_redirect.hpp
+++ b/lib/malloy/server/routing/endpoint_http_redirect.hpp
@@ -21,7 +21,7 @@ namespace malloy::server
         }
 
         [[nodiscard]]
-        handle_retr handle(const malloy::http::request& req, http::connection_t&) const override
+        handle_retr handle(const malloy::http::request& req, const http::connection_t&) const override
         {
             return malloy::http::generator::redirect(status, resource_new);
         }

--- a/lib/malloy/server/routing/endpoint_http_regex.hpp
+++ b/lib/malloy/server/routing/endpoint_http_regex.hpp
@@ -14,15 +14,15 @@ namespace malloy::server
         virtual bool matches_resource(const malloy::http::request& req) const = 0;
     };
 
-    template<typename... Bodies>
+    template<typename Response>
     struct endpoint_http_regex :
         endpoint_http, public resource_matcher
     {
-        using handler_t = std::function<std::variant<malloy::http::response<Bodies>...>(const malloy::http::request&)>;
+        using handler_t = std::function<Response(const malloy::http::request&)>;
 
         std::regex resource_base;
         handler_t handler;
-        writer_t<Bodies...> writer;
+        std::function<void(const malloy::http::request&, Response&&, const http::connection_t&)> writer;
 
         [[nodiscard]]
         bool matches_resource(const malloy::http::request& req) const override

--- a/lib/malloy/server/routing/endpoint_http_regex.hpp
+++ b/lib/malloy/server/routing/endpoint_http_regex.hpp
@@ -22,7 +22,7 @@ namespace malloy::server
 
         std::regex resource_base;
         handler_t handler;
-        std::function<void(const malloy::http::request&, malloy::http::response<Body>&&, http::connection_t&)> writer;
+        std::function<void(const malloy::http::request&, malloy::http::response<Body>&&, const http::connection_t&)> writer;
 
         [[nodiscard]]
         bool matches_resource(const malloy::http::request& req) const override
@@ -44,7 +44,7 @@ namespace malloy::server
         }
 
         [[nodiscard]]
-        handle_retr handle(const malloy::http::request& req, http::connection_t& conn) const override
+        handle_retr handle(const malloy::http::request& req, const http::connection_t& conn) const override
         {
             if (handler) {
                 writer(req, handler(req), conn);

--- a/lib/malloy/server/routing/endpoint_http_regex.hpp
+++ b/lib/malloy/server/routing/endpoint_http_regex.hpp
@@ -14,15 +14,15 @@ namespace malloy::server
         virtual bool matches_resource(const malloy::http::request& req) const = 0;
     };
 
-    template<typename Body>
+    template<typename... Bodies>
     struct endpoint_http_regex :
         endpoint_http, public resource_matcher
     {
-        using handler_t = std::function<malloy::http::response<Body>(const malloy::http::request&)>;
+        using handler_t = std::function<std::variant<malloy::http::response<Bodies>...>(const malloy::http::request&)>;
 
         std::regex resource_base;
         handler_t handler;
-        std::function<void(const malloy::http::request&, malloy::http::response<Body>&&, const http::connection_t&)> writer;
+        writer_t<Bodies...> writer;
 
         [[nodiscard]]
         bool matches_resource(const malloy::http::request& req) const override

--- a/lib/malloy/server/routing/endpoint_http_regex.hpp
+++ b/lib/malloy/server/routing/endpoint_http_regex.hpp
@@ -2,21 +2,30 @@
 
 #include "endpoint_http.hpp"
 
+#include "malloy/http/response.hpp"
+
 #include <functional>
 #include <regex>
 
 namespace malloy::server
 {
+    struct resource_matcher {
+        [[nodiscard]]
+        virtual bool matches_resource(const malloy::http::request& req) const = 0;
+    };
+
+    template<typename Body>
     struct endpoint_http_regex :
-        endpoint_http
+        endpoint_http, public resource_matcher
     {
-        using handler_t = std::function<malloy::http::response(const malloy::http::request&)>;
+        using handler_t = std::function<malloy::http::response<Body>(const malloy::http::request&)>;
 
         std::regex resource_base;
         handler_t handler;
+        std::function<void(const malloy::http::request&, malloy::http::response<Body>&&, http::connection_t&)> writer;
 
         [[nodiscard]]
-        bool matches_resource(const malloy::http::request& req) const
+        bool matches_resource(const malloy::http::request& req) const override
         {
             std::smatch match_result;
             std::string str{ req.uri().raw() };
@@ -35,10 +44,12 @@ namespace malloy::server
         }
 
         [[nodiscard]]
-        malloy::http::response handle(const malloy::http::request& req) const override
+        handle_retr handle(const malloy::http::request& req, http::connection_t& conn) const override
         {
-            if (handler)
-                return handler(req);
+            if (handler) {
+                writer(req, handler(req), conn);
+                return std::nullopt;
+            }
 
             return malloy::http::generator::server_error("no valid handler available.");
         }

--- a/lib/malloy/server/routing/router.cpp
+++ b/lib/malloy/server/routing/router.cpp
@@ -96,7 +96,7 @@ bool router::add_file_serving(std::string resource, std::filesystem::path storag
     auto ep = std::make_shared<endpoint_http_files>();
     ep->resource_base = resource;
     ep->base_path = std::move(storage_base_path);
-    ep->writer = [this](const auto& req, auto&& resp, auto& conn) { send_response(req, std::move(resp), &conn); };
+    ep->writer = [this](const auto& req, auto&& resp, const auto& conn) { send_response(req, std::move(resp), conn); };
 
     // Add
     return add_http_endpoint(std::move(ep));

--- a/lib/malloy/server/routing/router.cpp
+++ b/lib/malloy/server/routing/router.cpp
@@ -96,13 +96,15 @@ bool router::add_file_serving(std::string resource, std::filesystem::path storag
     auto ep = std::make_shared<endpoint_http_files>();
     ep->resource_base = resource;
     ep->base_path = std::move(storage_base_path);
-    ep->writer = [this](const auto& req, auto&& resp, const auto& conn) { send_response(req, std::move(resp), conn); };
+    ep->writer = [this](const auto& req, auto&& resp, const auto& conn) { 
+        std::visit([&, this](auto&& resp) { send_response(req, std::move(resp), conn);  }, std::move(resp));
+    };
 
     // Add
     return add_http_endpoint(std::move(ep));
 }
 
-bool router::add_redirect(const http::status status, std::string&& resource_old, std::string&& resource_new)
+bool router::add_redirect(const malloy::http::status status, std::string&& resource_old, std::string&& resource_new)
 {
     // Log
     if (m_logger)

--- a/lib/malloy/server/routing/router.cpp
+++ b/lib/malloy/server/routing/router.cpp
@@ -184,7 +184,7 @@ router::response_type router::generate_preflight_response(const request_type& re
             methods_string += ", ";
     }
 
-    malloy::http::response resp{ http::status::ok };
+    malloy::http::response resp{ malloy::http::status::ok };
     resp.set(boost::beast::http::field::content_type, "text/html");
     resp.base().set("Access-Control-Allow-Origin", "http://127.0.0.1:8080");
     resp.base().set("Access-Control-Allow-Methods", methods_string);

--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -11,7 +11,6 @@
 #include "malloy/server/http/connection/connection_plain.hpp"
 #include "malloy/server/http/connection/connection.hpp"
 
-#include <boost/beast/http/status.hpp>
 
 #if MALLOY_FEATURE_TLS
     #include "malloy/server/http/connection/connection_tls.hpp"
@@ -182,7 +181,10 @@ namespace malloy::server
             ep->resource_base = std::move(regex);
             ep->method = method;
             ep->handler = std::move(handler);
-            ep->writer = [this](const auto& req, auto&& resp, const auto& conn) { send_response(req, std::move(resp), conn); };
+            ep->writer = [this](const auto& req, auto&& resp, const auto& conn) { 
+                    std::visit([&, this](auto&& resp) { send_response(req, std::move(resp), conn);  }, std::move(resp));
+            };
+
 
             // Add route
             return add_http_endpoint(std::move(ep));

--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -11,6 +11,8 @@
 #include "malloy/server/http/connection/connection_plain.hpp"
 #include "malloy/server/http/connection/connection.hpp"
 
+#include <boost/beast/http/status.hpp>
+
 #if MALLOY_FEATURE_TLS
     #include "malloy/server/http/connection/connection_tls.hpp"
 #endif

--- a/lib/malloy/server/websocket/connection/connection_plain.hpp
+++ b/lib/malloy/server/websocket/connection/connection_plain.hpp
@@ -39,7 +39,7 @@ namespace malloy::server::websocket
         boost::beast::websocket::stream<boost::beast::tcp_stream> m_stream;
     };
 
-    std::shared_ptr<connection_plain>
+    inline std::shared_ptr<connection_plain>
     make_websocket_connection(
         std::shared_ptr<spdlog::logger> logger,
         boost::beast::tcp_stream stream

--- a/lib/malloy/server/websocket/connection/connection_tls.hpp
+++ b/lib/malloy/server/websocket/connection/connection_tls.hpp
@@ -38,7 +38,7 @@ namespace malloy::server::websocket
         boost::beast::websocket::stream<boost::beast::ssl_stream<boost::beast::tcp_stream>> m_stream;
     };
 
-    std::shared_ptr<connection_tls>
+    inline std::shared_ptr<connection_tls>
     make_websocket_connection(
         std::shared_ptr<spdlog::logger> logger,
         boost::beast::ssl_stream<boost::beast::tcp_stream> stream


### PR DESCRIPTION
This implements #13. Its not the most pretty implementation and I welcome any feedback on it or alternatives. All tests pass on both windows (msvc v142)  and linux (fedora 33/gcc 1.11.1). On MSVC it needs /bigobj to compile router.

Note this is, unfortunately, a breaking change. Most non-trivial code that currently uses this library will not compile against this patch. It is a compile error though, and is easy enough to fix, mostly just adding <> to the `response` and making some handlers return `std::variant<...>`. Again, feedback on this is welcome. 

I've done some basic testing of this server-side but I don't have a project currently that uses this client-side. I also haven't tested it with tls.

Notable changes:
- connection now accesses router through an interface, this was needed to break the include dependency cycle
- router no longer uses a template for connection, it uses a variant since there are only 4 it can be 
- concepts support is now required. Seems latest msvc and gcc both support them enough to compile
- response is now templated 
- generator::file now returns `std::variant<...file_body,...string_body...>` which is either an error response (as a string body) or the file 
- `router::add` is now templated and will accept _any_ function that takes in `const request_type&` and returns either a variant containing responses or a single response type (which is wrapped before being passed on). This allows _mostly_ seamless compatability with the exception being handlers that need to return multiple types of response (which now need to specifiy the variant explicitly, which is kind of horrible, maybe should be a using with only the body types passed?)
- endpoint_http_regex and endpoint_http_files use some horrible spagetti code to handle the non-string bodies

closes: #13 