### PR TITLE
feat: Optionally pass regex capture groups to router handler

### DIFF
--- a/lib/malloy/server/routing/endpoint_http_regex.hpp
+++ b/lib/malloy/server/routing/endpoint_http_regex.hpp
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <regex>
+#include <cassert>
 
 namespace malloy::server
 {
@@ -52,6 +53,12 @@ namespace malloy::server
             if (handler) {
                 if constexpr (WantsCapture) {
                     const auto url_matches = match_target(req);
+                    if (url_matches.empty()) {
+                        throw std::logic_error{
+                                R"(endpoint_http_regex passed request which does not match: )" +
+                            std::string{req.target()}};
+                    }
+
                     std::vector<std::string> matches{
                     // match_results[0] is the input string
                     url_matches.begin() + 1, url_matches.end()}; 

--- a/lib/malloy/server/routing/endpoint_http_regex.hpp
+++ b/lib/malloy/server/routing/endpoint_http_regex.hpp
@@ -32,7 +32,8 @@ namespace malloy::server
         [[nodiscard]]
         bool matches_resource(const malloy::http::request& req) const override
         {
-            return std::regex_match(req.target().begin(), req.target().end(), resource_base);
+            const auto url = req.uri();
+            return std::regex_match(url.raw().begin(), url.raw().end(), resource_base);
         }
 
         [[nodiscard]]

--- a/lib/malloy/server/routing/endpoint_http_regex.hpp
+++ b/lib/malloy/server/routing/endpoint_http_regex.hpp
@@ -52,10 +52,13 @@ namespace malloy::server
             if (handler) {
                 if constexpr (WantsCapture) {
                     const auto url_matches = match_target(req);
-                    std::vector matches{url_matches.begin() + 1, url_matches.end()}; // match_results[0] is the input string
-                    // TODO: Should we assert !matches.empty()? Might help catch bugs 
-                    writer(req, handler(req), matches);
-                } else {
+                    std::vector<std::string> matches{
+                    // match_results[0] is the input string
+                    url_matches.begin() + 1, url_matches.end()}; 
+
+                    writer(req, handler(req, matches), conn);
+                }
+                else {
                     writer(req, handler(req), conn);
                 }
                 return std::nullopt;
@@ -64,7 +67,7 @@ namespace malloy::server
             return malloy::http::generator::server_error("no valid handler available.");
         }
     private:
-        auto match_target(const malloy::http::request& req) -> std::smatch {
+        auto match_target(const malloy::http::request& req) const -> std::smatch {
             std::smatch match_result;
             std::string str{ req.uri().raw() };
             std::regex_match(str, match_result, resource_base);

--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -248,7 +248,9 @@ namespace malloy::server
                     continue;
 
                 // Log
-                m_logger->debug("invoking sub-router on {}", resource_base);
+                if (m_logger) {
+                    m_logger->debug("invoking sub-router on {}", resource_base);
+                }
 
                 // Chop request resource path
                 req.uri().chop_resource(resource_base);
@@ -281,10 +283,11 @@ namespace malloy::server
         )
         {
             // Log
-            m_logger->debug("handling HTTP request: {} {}",
-                req.method_string(),
-                req.uri().resource_string()
-            );
+            if (m_logger) {
+                m_logger->debug("handling HTTP request: {} {}",
+                                req.method_string(),
+                                req.uri().resource_string());
+            }
 
             // Check routes
             for (const auto& ep : m_endpoints_http) {
@@ -295,7 +298,9 @@ namespace malloy::server
                 // Generate preflight response (if supposed to)
                 if (m_generate_preflights && (req.method() == malloy::http::method::options)) {
                     // Log
-                    m_logger->debug("automatically constructing preflight response.");
+                    if (m_logger) {
+                        m_logger->debug("automatically constructing preflight response.");
+                    }
 
                     // Generate
                     auto resp = generate_preflight_response(req);
@@ -336,10 +341,11 @@ namespace malloy::server
             http::connection_t connection
         )
         {
-            m_logger->debug("handling WS request: {} {}",
-                req.method_string(),
-                req.uri().resource_string()
-            );
+            if (m_logger) {
+                m_logger->debug("handling WS request: {} {}",
+                                req.method_string(),
+                                req.uri().resource_string());
+            }
 
             // Check routes
             for (const auto& ep : m_endpoints_websocket) {
@@ -349,7 +355,9 @@ namespace malloy::server
 
                 // Validate route handler
                 if (!ep->handler) {
-                    m_logger->warn("websocket route with resource path \"{}\" has no valid handler assigned.");
+                    if (m_logger) {
+                        m_logger->warn("websocket route with resource path \"{}\" has no valid handler assigned.");
+                    }
                     continue;
                 }
 

--- a/test/test_suites/components/CMakeLists.txt
+++ b/test/test_suites/components/CMakeLists.txt
@@ -5,4 +5,5 @@ target_sources(
         response.cpp
         router.cpp
         uri.cpp
+        endpoints.cpp
 )

--- a/test/test_suites/components/CMakeLists.txt
+++ b/test/test_suites/components/CMakeLists.txt
@@ -6,4 +6,5 @@ target_sources(
         router.cpp
         uri.cpp
         endpoints.cpp
+        request.cpp
 )

--- a/test/test_suites/components/endpoints.cpp
+++ b/test/test_suites/components/endpoints.cpp
@@ -6,7 +6,7 @@ using namespace malloy::http;
 using namespace malloy::server;
 
 
-void endpt_handle(const auto& endpt, const std::string_view& url) {
+void endpt_handle(const auto& endpt, const std::string& url) {
     request req{method::get, "", 0, url};
     [[maybe_unused]]const auto rs = endpt.handle(req, http::connection_t{std::shared_ptr<http::connection_plain>{nullptr}});
 }
@@ -21,7 +21,7 @@ TEST_SUITE("components - endpoints") {
         constexpr auto second_cap = "42";
 
         const auto input_url = std::string{"/content/"} + first_cap + "/" + second_cap;
-        std::regex input_reg{R"(/content/(\w+)/([0-9]+))"};
+        std::regex input_reg{R"(/content/(\w+)/(\d+))"};
         endpoint_http_regex<response<>, true> endpt;
 
         bool handler_called{false};
@@ -33,6 +33,7 @@ TEST_SUITE("components - endpoints") {
 
             return generator::ok();
         };
+        endpt.resource_base = input_reg;
         endpt.writer = [](auto&&...){};
 
         endpt_handle(endpt, input_url);
@@ -49,6 +50,7 @@ TEST_SUITE("components - endpoints") {
             (*called) = true;
             return generator::ok();
         };
+        endpt.resource_base = input_reg;
         endpt.writer = [](auto&&...) {};
 
         endpt_handle(endpt, input_url);

--- a/test/test_suites/components/endpoints.cpp
+++ b/test/test_suites/components/endpoints.cpp
@@ -1,0 +1,61 @@
+#include "../../test.hpp"
+
+#include <malloy/server/routing/endpoint_http_regex.hpp>
+
+using namespace malloy::http;
+using namespace malloy::server;
+
+
+void endpt_handle(const auto& endpt, const std::string_view& url) {
+    request req{method::get, "", 0, url};
+    [[maybe_unused]]const auto rs = endpt.handle(req, http::connection_t{std::shared_ptr<http::connection_plain>{nullptr}});
+}
+
+TEST_SUITE("components - endpoints") {
+    TEST_CASE("An http_regex_endpoint with a handler that takes "
+              "std::vector<std::string> as an additional param will pass the "
+              "values of the capture groups in the input regex as elements of "
+              "that vector")
+    {
+        constexpr auto first_cap = "thisisaword";
+        constexpr auto second_cap = "42";
+
+        const auto input_url = std::string{"/content/"} + first_cap + "/" + second_cap;
+        std::regex input_reg{R"(/content/(\w+)/([0-9]+))"};
+        endpoint_http_regex<response<>, true> endpt;
+
+        bool handler_called{false};
+        endpt.handler = [&, called = &handler_called](const auto& req, const std::vector<std::string>& results) {
+            CHECK(results.size() == 2);
+            CHECK(results.at(0) == first_cap);
+            CHECK(results.at(1) == second_cap);
+            (*called) = true;
+
+            return generator::ok();
+        };
+        endpt.writer = [](auto&&...){};
+
+        endpt_handle(endpt, input_url);
+        CHECK(handler_called);
+        
+    }
+    TEST_CASE("An endpoint_http_regex with a handler that only accepts malloy::http::request will not try to pass capture group values"){
+        constexpr auto input_url = "/content/word";
+        const auto input_reg{R"(/content/(\w+))"};
+
+        endpoint_http_regex<response<>, false> endpt;
+        bool handler_called{false};
+        endpt.handler = [called = &handler_called](const auto& req) {
+            (*called) = true;
+            return generator::ok();
+        };
+        endpt.writer = [](auto&&...) {};
+
+        endpt_handle(endpt, input_url);
+        CHECK(handler_called);
+        
+
+
+    }
+}
+

--- a/test/test_suites/components/endpoints.cpp
+++ b/test/test_suites/components/endpoints.cpp
@@ -7,7 +7,7 @@ using namespace malloy::server;
 
 
 void endpt_handle(const auto& endpt, const std::string& url) {
-    request req{method::get, "", 0, url};
+    request req{boost::beast::http::request<boost::beast::http::string_body>{method::get, url, 1}};
     [[maybe_unused]]const auto rs = endpt.handle(req, http::connection_t{std::shared_ptr<http::connection_plain>{nullptr}});
 }
 

--- a/test/test_suites/components/request.cpp
+++ b/test/test_suites/components/request.cpp
@@ -1,0 +1,28 @@
+#include "../../test.hpp"
+
+#include <malloy/http/request.hpp> 
+
+using namespace malloy::http;
+namespace bhttp = boost::beast::http;
+
+TEST_SUITE("components - request") {
+    TEST_CASE("ctor") {
+        const std::string target = "/test";
+
+        SUBCASE("Constructing a request with a beast request results in a uri matching the target") {
+            bhttp::request<bhttp::string_body> req;
+            req.target(target);
+
+            request mreq{std::move(req)};
+
+            CHECK(mreq.uri().raw() == target);
+        }
+
+        SUBCASE("Constructing a request with a target string results in a uri matching the target") {
+            request req{method::get, "", 0, target};
+            CHECK(req.uri().raw() == target);
+        }
+    }
+
+}
+

--- a/test/test_suites/components/router.cpp
+++ b/test/test_suites/components/router.cpp
@@ -54,5 +54,6 @@ TEST_SUITE("components - router")
         }
 
     }
+    TEST_CASE("A ")
 
 }

--- a/test/test_suites/components/router.cpp
+++ b/test/test_suites/components/router.cpp
@@ -8,6 +8,16 @@ using namespace malloy::server;
 TEST_SUITE("components - router")
 {
 
+    TEST_CASE("add [regex]") {
+        router r;
+        SUBCASE("Adding a handler with only a request compiles") {
+            r.add(method::get, "", [](const auto&) { return generator::ok(); });
+        }
+        SUBCASE("Adding a handler with a request and capture results compiles") {
+            r.add(method::get, "", [](const auto&, const auto&){ return generator::ok(); });
+        }
+    }
+
     TEST_CASE("add [redirect]")
     {
         router r;

--- a/test/test_suites/components/router.cpp
+++ b/test/test_suites/components/router.cpp
@@ -54,6 +54,5 @@ TEST_SUITE("components - router")
         }
 
     }
-    TEST_CASE("A ")
 
 }


### PR DESCRIPTION
This allows handlers for `router::add` to have an optional second parameter. To support this, `endpoint_http_regex` is now templated on whether the handler uses the extra argument. It uses this to decide at compile-time whether to do the extra regex match on `handle`. Note it uses no caching and will (redundently) match the same string twice. I considered adding caching but I think that borders on premature optimsation, especially since it would mean removing the `const`ness of `handle(...)` etc al. 

I have added tests for it which currently pass. It no longer uses `uri` when matching due to a bug I found in `request` when writing the tests and because ~~I'm not sure what the point is (validation?).~~ ok so that was needed for subrouters. I've reset it to using uri and the tests are using the `beast::...::request` ctor to get around the bug. The bug is reproduced in a test I've included in this patch (which currently fails). The problem is that `request`'s ctor that takes `target` does not inititalise `m_uri`.

Also it requires /bigobj to compile on MSVC. I'm not sure if thats due to this or #14. Either way, `malloy-objs` should make that a public option since anything including its headers will need it.

closes: #12, closes: #10