### PR TITLE
fix: Compile of router::add on gcc <=11with non-variant return

### DIFF
--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -40,10 +40,6 @@ namespace spdlog
 namespace malloy::server
 {
     namespace detail {
-        struct any_callable {
-                template<typename T>
-                void operator()(T&&) {}
-        };
         template<typename T, typename H>
         concept has_handler = requires(T t, H h) { t.set_handler(h); };
 
@@ -52,7 +48,7 @@ namespace malloy::server
 
         template<typename V>
         concept is_variant = requires(V v) { 
-            std::visit(any_callable{}, v); 
+            []<typename... Args>(const std::variant<Args...>& vs){}(v); // https://stackoverflow.com/q/68115853/12448530
         };
 
     }


### PR DESCRIPTION
This is due to it not implementing P2162 yet as described [here](https://stackoverflow.com/q/68115853/12448530). GCC trunk does implement this though (tested with godbolt), but since the replacement code is cleaner anyway imo, its not really an issue