### PR TITLE
Misc CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu-latest 
             msvc: false
           - os: windows-latest 
-            msvc: true
+            msvc: false
 
     continue-on-error: ${{ matrix.experimental }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         exclude:
           - os: ubuntu-latest 
             msvc: false
+          - os: windows-latest 
+            msvc: true
 
     continue-on-error: ${{ matrix.experimental }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         exclude:
           - os: ubuntu-latest 
             msvc: false
-          - os: windows-latest 
-            msvc: false
+          - os: windows-latest  
+            msvc: false # choco package for mingw 10.2.0 does not support threads, see: #21
 
     continue-on-error: ${{ matrix.experimental }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on: 
   push:
-    branches: [main, feat-ci]
   pull_request: 
     branches: [main]
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ option(MALLOY_FEATURE_HTML   "Whether to enable HTML features" ON)
 option(MALLOY_FEATURE_TLS    "Whether to enable TLS features"  OFF)
 option(MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD "Whether to automatically fetch spdlog" ON)
 
+include(${CMAKE_CURRENT_LIST_DIR}/utils.cmake)
+
 # Set dependencies accordingly
 if (MALLOY_FEATURE_TLS)
     set(MALLOY_DEPENDENCY_OPENSSL ON)

--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_subdirectory(http-plain)
-add_subdirectory(http_tls)
 add_subdirectory(websocket-plain)
+
+if (MALLOY_FEATURE_TLS)
+    add_subdirectory(http_tls)
+endif()
+

--- a/examples/client/example.cmake
+++ b/examples/client/example.cmake
@@ -5,10 +5,5 @@ function(malloy_example_setup_client target)
             malloy-objs
     )
 
-    target_compile_options(
-        ${target}
-        PRIVATE
-            $<$<BOOL:${WIN32}>:-Wa,-mbig-obj>
-            $<$<BOOL:${WIN32}>:-O3>
-    )
+    malloy_setup_defines(${target})
 endfunction()

--- a/examples/server/example.cmake
+++ b/examples/server/example.cmake
@@ -5,10 +5,5 @@ function(malloy_example_setup target)
             malloy-objs
     )
 
-    target_compile_options(
-        ${target}
-        PRIVATE
-            $<$<BOOL:${WIN32}>:-Wa,-mbig-obj>
-            $<$<BOOL:${WIN32}>:-O3>
-    )
+    malloy_setup_defines(${target})
 endfunction()

--- a/lib/malloy/CMakeLists.txt
+++ b/lib/malloy/CMakeLists.txt
@@ -62,10 +62,10 @@ target_link_libraries(
     PUBLIC
         spdlog::spdlog
         Boost::headers
+        $<$<BOOL:${MALLOY_FEATURE_TLS}>:OpenSSL::Crypto>
+        $<$<BOOL:${MALLOY_FEATURE_TLS}>:OpenSSL::SSL>
+        $<$<AND:$<BOOL:${MALLOY_FEATURE_TLS}>,$<BOOL:${WIN32}>>:crypt32>        # ToDo: This is only needed when MALLOY_FEATURE_CLIENT is ON
     PRIVATE
         $<$<BOOL:${WIN32}>:wsock32>
         $<$<BOOL:${WIN32}>:ws2_32>
-        $<$<AND:$<BOOL:${MALLOY_FEATURE_TLS}>,$<BOOL:${WIN32}>>:crypt32>        # ToDo: This is only needed when MALLOY_FEATURE_CLIENT is ON
-        $<$<BOOL:${MALLOY_FEATURE_TLS}>:OpenSSL::Crypto>
-        $<$<BOOL:${MALLOY_FEATURE_TLS}>:OpenSSL::SSL>
-)
+    )

--- a/lib/malloy/CMakeLists.txt
+++ b/lib/malloy/CMakeLists.txt
@@ -27,13 +27,8 @@ target_compile_features(
         cxx_std_20
 )
 
-target_compile_options(
-    ${TARGET_OBJS}
-    PRIVATE
-        $<$<BOOL:${MINGW}>:-Wa,-mbig-obj>
-        $<$<BOOL:${MINGW}>:-O3>
-        $<$<BOOL:${MSVC}>:/bigobj>
-)
+malloy_setup_defines(${TARGET_OBJS})
+
 
 target_compile_definitions(
     ${TARGET_OBJS}
@@ -43,9 +38,7 @@ target_compile_definitions(
         $<$<BOOL:${WIN32}>:UNICODE>
         $<$<BOOL:${WIN32}>:_UNICODE>
         $<$<BOOL:${WIN32}>:WIN32_LEAN_AND_MEAN>
-    PRIVATE
-        $<$<BOOL:${WIN32}>:BOOST_DATE_TIME_NO_LIB>
-)
+    )
 
 target_include_directories(
     ${TARGET_OBJS}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,9 @@ add_executable(${TARGET})
 
 add_subdirectory(test_suites)
 
+
+malloy_setup_defines(${TARGET})
+
 target_include_directories(
     ${TARGET}
     PRIVATE

--- a/utils.cmake
+++ b/utils.cmake
@@ -1,0 +1,14 @@
+function(malloy_setup_defines TARGET)
+  target_compile_options(
+    ${TARGET} 
+    PRIVATE 
+        $<$<BOOL:${MINGW}>:-Wa,-mbig-obj> 
+        $<$<BOOL:${MINGW}>:-O3>
+        $<$<BOOL:${MSVC}>:/bigobj>
+    )
+  target_compile_definitions(
+      ${TARGET} 
+      PRIVATE 
+        $<$<BOOL:${WIN32}>:BOOST_DATE_TIME_NO_LIB>
+    )
+endfunction()


### PR DESCRIPTION
This makes some minor changes to the CI and build files so that it will now pass in every tested environment. Note that it does remove mingw compilation because the choco package for 10.2.0 lacks thread support and 8.1.0 can't compile this library (doesn't support enough 20). I tried setting up msys2 instead but it still used the default installed gcc (8.1.0) and I'm not sure how to fix that. I can add it back if needed but having a CI run that always fails due to external problems rather than an issue with the library itself is not very useful imo.

Main changes:
- The boost define and various compiler flags needed are now wrapped in a cmake function called for tests, malloy-objs, and the examples
- The CI now runs on any branch being pushed (this is mostly for the benefit of forks)
- The client tls example is now build conditional on TLS being enabled 
- openssl is now linked to publicly. This is similar to #9 in that it worked when the headers were in the system path, but not when specified by cmake (e.g. in the case of msvc using choco openssl).

The result is that the CI passes and therefore this library and its examples can be built with boost version 1.74.0 through 1.76.0 with or without tls on gcc-11 and the latest (stable) msvc.