### PR TITLE
Add clang-format lint check to CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@
 BasedOnStyle: LLVM
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: None
+AlignConsecutiveAssignments: false
 AlignOperands: Align
 AllowAllArgumentsOnNextLine: false
 AllowAllConstructorInitializersOnNextLine: true

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,27 @@
+name: clang-format check 
+
+on:
+  pull_request: 
+
+jobs:
+  build:
+    runs-on: ubuntu-latest 
+    steps:
+      - uses: actions/checkout@v2 
+        with:
+          fetch-depth: 0 
+      - name: Run clang-format 
+        run: |
+          find ./lib ./test -print0 -iname "*.cpp" -o -iname "*.hpp" | xargs -0 clang-format -i --style=file
+      - name: Commit changes
+        run: | 
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "clang-format [bot]"
+          git commit -am "ci: run formatter [skip ci]"
+      - name: Push changes 
+        run: |
+          git push HEAD:"${{ github.head_ref }}" "https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git"
+
+
+
+

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -2,10 +2,13 @@ name: clang-format check
 
 on:
   pull_request: 
+  push:
 
 jobs:
   check-fmt:
     runs-on: ubuntu-latest 
+    name: "clang-format"
+    if: "!contains(github.event.head_commit.message, '[skip lint]')"
     steps:
       - uses: actions/checkout@v2 
         with:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -12,16 +12,11 @@ jobs:
           fetch-depth: 0 
       - name: Run clang-format 
         run: |
-          find ./lib ./test -print0 -iname "*.cpp" -o -iname "*.hpp" | xargs -0 clang-format -i --style=file
-      - name: Commit changes
-        run: | 
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "clang-format [bot]"
-          git commit -am "ci: run formatter [skip ci]"
-      - name: Push changes 
-        run: |
-          git push HEAD:"${{ github.head_ref }}" "https://${{ github.actor }}:${{ github.token }}@github.com/${{ github.repository }}.git"
-
-
+            # This magic invocation to find will: 
+            # - list every file ending in .hpp or .cpp recursively in 
+            #   - ./lib
+            #   - ./test 
+            # unless the path contains a directory named 3rdparty in it
+            find ./lib ./test -type d -name "3rdparty" -prune -false -o -type f -iname "*.cpp" -o -iname "*.hpp" -print0 | xargs -0 clang-format --style=file -Werror --dry-run
 
 

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,7 +4,7 @@ on:
   pull_request: 
 
 jobs:
-  build:
+  check-fmt:
     runs-on: ubuntu-latest 
     steps:
       - uses: actions/checkout@v2 


### PR DESCRIPTION
This adds a check which will fail if the code in a PR or push is not formatted according to the `.clang-format` file. It skips 3rdparty code. 

It also has a fix for the `.clang-format` file since the CI version took issue with it. I assume thats because it runs an earlier version of clang-format.

Note this currently fails. I've tested it by running `clang-format -i` over the codebase and the command succeeds after that. 

Ref: #22 