### PR TITLE
Add msys2/mingw to CI

### DIFF
--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -27,13 +27,20 @@ jobs:
         run:
             shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v2
       
       - uses: msys2/setup-msys2@v2
         with:
             msystem: MINGW64
-            update: true
-            install: git mingw-w64-x86_64-toolchain cmake ninja
+            update: false
+            install: >-
+              git 
+              base-devel
+              mingw-w64-x86_64-toolchain 
+              mingw-w64-x86_64-cmake 
+              mingw-w64-x86_64-spdlog
+              p7zip
+
+      - uses: actions/checkout@v2
       - name: cache boost
         uses: actions/cache@v2 
         id: cache-boost
@@ -48,10 +55,12 @@ jobs:
       - name: Install Boost
         if: steps.cache-boost.outputs.cache-hit != 'true'
         run: |
-          if [ "$OS" == "Windows_NT" ]; then
-            # fix up paths to be forward slashes consistently
-            BOOST_ROOT=$(echo $BOOST_ROOT | sed 's/\\/\//g')
-          fi
+          # This sed magic does two things:
+          # 1. Replaces backslashes with forward slashes
+          # 2. Replaces windows drive paths (e.g. D:) with msys paths (e.g. /d)
+          BOOST_ROOT=$(echo $BOOST_ROOT | sed 's/\\/\//g' | sed 's/\([A-Z]\):/\/\L\1/g')
+          echo "BOOST_ROOT=$BOOST_ROOT" >> $GITHUB_ENV
+          echo "BOOST ROOT: ${BOOST_ROOT}"
           mkdir -p $BOOST_ROOT
           curl --progress-bar --location --output $BOOST_ROOT/download.tar.bz2 $BOOST_URL
           7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar.bz2 -y -bd
@@ -60,7 +69,7 @@ jobs:
           rm -rf boost_*/* download.tar.bz2 download.tar
      
       - name: Configure 
-        run: cmake -Bbuild -GNinja -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.malloy_tls }}
+        run: cmake -Bbuild -G"MSYS Makefiles" -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.malloy_tls }} -DMALLOY_DEPENDENCY_SPDLOG_DOWNLOAD=OFF
 
       - name: Build 
         run: cmake --build build 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -44,7 +44,6 @@ jobs:
         run: |
           BOOST_URL="https://boostorg.jfrog.io/artifactory/main/release/${{ matrix.boost_version }}/source/boost_$(echo ${{ matrix.boost_version }} | sed 's/\./_/g').tar.bz2"
           echo "BOOST_URL=$BOOST_URL" >> $GITHUB_ENV
-        shell: bash
 
       - name: Install Boost
         if: steps.cache-boost.outputs.cache-hit != 'true'
@@ -59,7 +58,6 @@ jobs:
           7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar -y -bd
           cd $BOOST_ROOT && cp -r boost_*/* .
           rm -rf boost_*/* download.tar.bz2 download.tar
-        shell: bash
      
       - name: Configure 
         run: cmake -Bbuild -GNinja -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.malloy_tls }}

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,0 +1,79 @@
+name: MSYS2 CI
+
+on: 
+  push:
+  pull_request: 
+    branches: [main]
+
+env: 
+  BUILD_TYPE: Release 
+  INSTALL_LOCATION: .local 
+
+jobs:
+  build:
+    strategy: 
+      fail-fast: false
+      matrix:
+        boost_version: [1.74.0, 1.76.0]
+        malloy_tls: [ON, OFF]
+        
+    runs-on: windows-latest
+    env:
+      BOOST_ROOT: ${{github.workspace}}/3rdparty/boost-${{ matrix.boost_version }}
+
+    name: 'mingw: boost ${{ matrix.boost_version }} tls: ${{ matrix.malloy_tls }}'
+    if: "!contains(github.event.head_commit.message, '[ci skip]')"
+    default:
+        run:
+            shell: msys2 {0}
+    steps:
+      - uses: actions/checkout@v2
+      
+      - uses: msys2/setup-msys2@v2
+        with:
+            msystem: MINGW64
+            update: true
+            install: git mingw-w64-x86_64-toolchain 
+      - name: cache boost
+        uses: actions/cache@v2 
+        id: cache-boost
+        with: 
+          path: ${{ env.BOOST_ROOT }}
+          key: boost-${{ matrix.boost_version }}
+      - name: Install Ninja 
+        uses: seanmiddleditch/gha-setup-ninja@master
+      - name: Setup boost env
+        run: |
+          BOOST_URL="https://boostorg.jfrog.io/artifactory/main/release/${{ matrix.boost_version }}/source/boost_$(echo ${{ matrix.boost_version }} | sed 's/\./_/g').tar.bz2"
+          echo "BOOST_URL=$BOOST_URL" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Install Boost
+        if: steps.cache-boost.outputs.cache-hit != 'true'
+        run: |
+          if [ "$OS" == "Windows_NT" ]; then
+            # fix up paths to be forward slashes consistently
+            BOOST_ROOT=$(echo $BOOST_ROOT | sed 's/\\/\//g')
+          fi
+          mkdir -p $BOOST_ROOT
+          curl --progress-bar --location --output $BOOST_ROOT/download.tar.bz2 $BOOST_URL
+          7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar.bz2 -y -bd
+          7z -o$BOOST_ROOT x $BOOST_ROOT/download.tar -y -bd
+          cd $BOOST_ROOT && cp -r boost_*/* .
+          rm -rf boost_*/* download.tar.bz2 download.tar
+        shell: bash
+     
+      - name: Configure 
+        run: cmake -Bbuild -GNinja -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.malloy_tls }}
+
+      - name: Build 
+        run: cmake --build build 
+
+      - name: Run tests 
+        run: ./build/test/malloy-tests
+
+
+    
+
+
+

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -33,11 +33,9 @@ jobs:
             msystem: MINGW64
             update: false
             install: >-
-              git 
               base-devel
               mingw-w64-x86_64-toolchain 
               mingw-w64-x86_64-cmake 
-              mingw-w64-x86_64-spdlog
               p7zip
 
       - uses: actions/checkout@v2
@@ -69,7 +67,7 @@ jobs:
           rm -rf boost_*/* download.tar.bz2 download.tar
      
       - name: Configure 
-        run: cmake -Bbuild -G"MSYS Makefiles" -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.malloy_tls }} -DMALLOY_DEPENDENCY_SPDLOG_DOWNLOAD=OFF
+        run: cmake -Bbuild -G"MSYS Makefiles" -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.malloy_tls }} -DMALLOY_DEPENDENCY_SPDLOG_DOWNLOAD=ON
 
       - name: Build 
         run: cmake --build build 

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -33,7 +33,7 @@ jobs:
         with:
             msystem: MINGW64
             update: true
-            install: git mingw-w64-x86_64-toolchain 
+            install: git mingw-w64-x86_64-toolchain cmake
       - name: cache boost
         uses: actions/cache@v2 
         id: cache-boost

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -23,7 +23,7 @@ jobs:
 
     name: 'mingw: boost ${{ matrix.boost_version }} tls: ${{ matrix.malloy_tls }}'
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
-    default:
+    defaults:
         run:
             shell: msys2 {0}
     steps:

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -33,15 +33,13 @@ jobs:
         with:
             msystem: MINGW64
             update: true
-            install: git mingw-w64-x86_64-toolchain cmake
+            install: git mingw-w64-x86_64-toolchain cmake ninja
       - name: cache boost
         uses: actions/cache@v2 
         id: cache-boost
         with: 
           path: ${{ env.BOOST_ROOT }}
           key: boost-${{ matrix.boost_version }}
-      - name: Install Ninja 
-        uses: seanmiddleditch/gha-setup-ninja@master
       - name: Setup boost env
         run: |
           BOOST_URL="https://boostorg.jfrog.io/artifactory/main/release/${{ matrix.boost_version }}/source/boost_$(echo ${{ matrix.boost_version }} | sed 's/\./_/g').tar.bz2"


### PR DESCRIPTION
This adds a workflow that builds with msys2/mingw on pushes to any branch or pull requests to `main`. It currently builds with TLS ON/OFF and boost versions 1.74.0 and 1.76.0 (1.75.0 skipped because of #19). The build takes... a while. I'm not sure if thats due to using `MSYS Makefiles` rather than `Ninja` or just mingw (on my machine it takes ~15 minutes to compile clean whereas msvc takes 2-3, thats with `Ninja`). It also uses an external version of spdlog (mingw-w64-x86_64-spdlog) since there was an issue when trying to fetch it via cmake.

Closes: #27 