### PR TITLE
Fixup Callback type of `client::controller::http_request`

### DIFF
--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -99,6 +99,7 @@ namespace malloy::client
          * @sa https_request()
          */
         template<malloy::http::concepts::body ReqBody, typename Callback, concepts::response_filter Filter = detail::default_resp_filter>
+        requires concepts::http_callback<Callback, Filter>
         [[nodiscard]] auto http_request(malloy::http::request<ReqBody> req, Callback&& done, Filter filter = {}) -> std::future<malloy::error_code>
         {
 
@@ -129,6 +130,7 @@ namespace malloy::client
          * @sa http_request()
          */
         template<malloy::http::concepts::body ReqBody, typename Callback, concepts::response_filter Filter = detail::default_resp_filter>
+        requires concepts::http_callback<Callback, Filter>
         [[nodiscard]] auto https_request(malloy::http::request<ReqBody> req, Callback&& done, Filter filter = {}) -> std::future<malloy::error_code>
         {
             check_tls();

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -85,11 +85,7 @@ namespace malloy::client
          * Perform a plain (unencrypted) HTTP request.
          *
          * @param req The HTTP request.
-         * @param done Callback invoked on completion. Must be a visitor over
-         * `malloy::http::response<T>...` where T is the types contained in the
-         * return type of `Filter::body_for` (see response_filter @ref
-         * client_concepts). If you do not pass anything for filter, it just
-         * needs to take `malloy::http::response<>&&` as its only parameter 
+         * @param done Callback invoked on completion. Must satisfy http_callback (@ref client_concepts) with Filter
          * @param filter Filter to use when parsing the response. Must satisfy
          * response_filter @ref client_concepts
          *

--- a/lib/malloy/client/http/connection.hpp
+++ b/lib/malloy/client/http/connection.hpp
@@ -178,7 +178,7 @@ namespace malloy::client::http
                         return;
                     }
                     // Notify via callback
-                    (*m_cb)(parser->release());
+                    (*m_cb)(malloy::http::response<body_t>{parser->release()});
                     on_read();
                 }
                 );

--- a/lib/malloy/client/type_traits.hpp
+++ b/lib/malloy/client/type_traits.hpp
@@ -9,6 +9,14 @@
 namespace malloy::client::concepts {
     namespace detail
     {
+        /**
+         * @class http_cb_helper
+         * @brief Helper for http_callback concept
+         * @note This is effectively [cb = std::move(cb)]<typename V>(V&& v) mutable { ... }
+         * @tparam Callback carries the functor type being checked by the
+         * concept
+         *
+         */
         template<typename Callback>
         struct http_cb_helper {
             Callback cb;

--- a/lib/malloy/client/type_traits.hpp
+++ b/lib/malloy/client/type_traits.hpp
@@ -58,6 +58,13 @@ namespace malloy::client::concepts {
  * - `f.body_for(h) -> std::variant<Ts...>`
  * - `std::visit([](auto& v){ decltype(v)::value_type r; f.setup_body(h, r); }, f.body_for(h))` 
  *   (setup_body must be a visitor over the value_types of the response bodies returned by `f.body_for(h)`)
+ * 
+ * @section http_callback
+ * @par Callback type used to provide responses to http(s) requests. Takes another type that satisfies response_filter, referred to as Filter from now on.
+ * 
+ * @par Requires:
+ * - `std::move_constructible` 
+ * - `(malloy::http::response<Ts>&&) -> void` where `Filter::body_for(..) -> std::variant<Ts...>`.
  *
  *
  */


### PR DESCRIPTION
This patches the issues raised in: #47 about the lack of a constraint on the `Callback` type of `client::controller::http_request` and the wrong response type being passed to it.