### PR TITLE
fix: subrouter endpoint_http_regex not matching

### DIFF
--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -285,6 +285,7 @@ namespace malloy::server
 
                 // Chop request resource path
                 location.chop_resource(resource_base);
+                req->header().target(location.raw());
 
                 // Let the sub-router handle things from here...
                 router->template handle_request<isWebsocket, Derived>(doc_root, std::move(req), connection, location);


### PR DESCRIPTION
Fixes: #56 

This ones on me. I remember doing some testing here but I think that must've only been with the file and websocket endpoints. I don't really use subrouters currently so I didn't catch it, sorry :p.