### PR TITLE
Add custom agent strings

### DIFF
--- a/lib/malloy/client/controller.cpp
+++ b/lib/malloy/client/controller.cpp
@@ -18,8 +18,12 @@ auto controller::run() -> bool
     return true;
 }
 
-void controller::after_init(config&& cfg) {
+auto controller::init(config cfg) -> bool {
+    if (!malloy::controller::init(cfg)) {
+        return false;
+    }
     m_cfg = std::move(cfg);
+    return true;
 }
 
 #if MALLOY_FEATURE_TLS

--- a/lib/malloy/client/controller.cpp
+++ b/lib/malloy/client/controller.cpp
@@ -18,6 +18,10 @@ auto controller::run() -> bool
     return true;
 }
 
+void controller::after_init(config&& cfg) {
+    m_cfg = std::move(cfg);
+}
+
 #if MALLOY_FEATURE_TLS
     bool controller::init_tls()
     {

--- a/lib/malloy/client/controller.cpp
+++ b/lib/malloy/client/controller.cpp
@@ -25,6 +25,9 @@ auto controller::init(config cfg) -> bool {
     m_cfg = std::move(cfg);
     return true;
 }
+auto controller::start() -> bool {
+    return root_start(m_cfg);
+}
 
 #if MALLOY_FEATURE_TLS
     bool controller::init_tls()

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -18,7 +18,6 @@
 #endif
 
 #include <boost/asio/strand.hpp>
-#include <boost/beast/version.hpp>
 #include <spdlog/logger.h>
 
 #include <filesystem>
@@ -71,7 +70,8 @@ namespace malloy::client
             malloy::controller::config {
 
             /**
-             * @brief Agent string used for websocket connections
+             * @brief Agent string used for connections
+             * @details Set as the User-Agent in http headers
              */
             std::string user_agent{"malloy-client"};
         };

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -9,6 +9,7 @@
 #include "../core/http/type_traits.hpp"
 #include "../core/error.hpp"
 
+
 #if MALLOY_FEATURE_TLS
     #include "http/connection_tls.hpp"
 
@@ -16,6 +17,7 @@
 #endif
 
 #include <boost/asio/strand.hpp>
+#include <boost/beast/version.hpp>
 #include <spdlog/logger.h>
 
 #include <filesystem>
@@ -66,6 +68,7 @@ namespace malloy::client
     public:
         struct config :
             malloy::controller::config {
+
             /**
              * @brief Agent string used for websocket connections
              */
@@ -226,8 +229,9 @@ namespace malloy::client
          */
         auto run() -> bool;
 
+        auto start() -> bool;
+
     protected:
-        void after_init(config&& cfg) override;
 
     private:
         std::shared_ptr<boost::asio::ssl::context> m_tls_ctx;

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -269,7 +269,7 @@ namespace malloy::client
                             } else
 #endif
                                 return malloy::websocket::stream{boost::beast::tcp_stream{boost::asio::make_strand(io_ctx())}};
-                        }());
+                        }(), m_cfg.ws_agent_string);
 
                         conn->connect(results, resource, [conn, done = std::forward<decltype(done)>(done)](auto ec) mutable {
                             if (ec) {

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -231,7 +231,7 @@ namespace malloy::client
             }();
 
             if (!malloy::http::has_field(req, malloy::http::field::user_agent)) {
-                req[malloy::http::field::user_agent] = m_cfg.ws_agent_string;
+                req.set(malloy::http::field::user_agent, m_cfg.ws_agent_string);
             }
 
             // Run

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -73,7 +73,7 @@ namespace malloy::client
             /**
              * @brief Agent string used for websocket connections
              */
-            std::string user_agent{BOOST_BEAST_VERSION_STRING " malloy-client"};
+            std::string user_agent{"malloy-client"};
         };
 
         controller() = default;

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -73,7 +73,7 @@ namespace malloy::client
             /**
              * @brief Agent string used for websocket connections
              */
-            std::string ws_agent_string{BOOST_BEAST_VERSION_STRING " malloy-client"};
+            std::string user_agent{BOOST_BEAST_VERSION_STRING " malloy-client"};
         };
 
         controller() = default;
@@ -231,7 +231,7 @@ namespace malloy::client
             }();
 
             if (!malloy::http::has_field(req, malloy::http::field::user_agent)) {
-                req.set(malloy::http::field::user_agent, m_cfg.ws_agent_string);
+                req.set(malloy::http::field::user_agent, m_cfg.user_agent);
             }
 
             // Run
@@ -274,7 +274,7 @@ namespace malloy::client
                             } else
 #endif
                                 return malloy::websocket::stream{boost::beast::tcp_stream{boost::asio::make_strand(io_ctx())}};
-                        }(), m_cfg.ws_agent_string);
+                        }(), m_cfg.user_agent);
 
                         conn->connect(results, resource, [conn, done = std::forward<decltype(done)>(done)](auto ec) mutable {
                             if (ec) {

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -66,10 +66,17 @@ namespace malloy::client
     public:
         struct config :
             malloy::controller::config {
+            /**
+             * @brief Agent string used for websocket connections
+             */
+            std::string ws_agent_string{BOOST_BEAST_VERSION_STRING " malloy-client"};
         };
 
         controller() = default;
         ~controller() override = default;
+
+        [[nodiscard("init may fail")]]
+        auto init(config cfg) -> bool;
 
 #if MALLOY_FEATURE_TLS
         /**

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -219,8 +219,12 @@ namespace malloy::client
          */
         auto run() -> bool;
 
+    protected:
+        void after_init(config&& cfg) override;
+
     private:
         std::shared_ptr<boost::asio::ssl::context> m_tls_ctx;
+        config m_cfg;
 
         /**
          * Checks whether the TLS context was initialized.

--- a/lib/malloy/core/controller.cpp
+++ b/lib/malloy/core/controller.cpp
@@ -11,7 +11,7 @@ controller::~controller()
     stop().wait();
 }
 
-bool controller::init(config cfg)
+bool controller::init(const config& cfg)
 {
     // Don't initialize if not stopped
     if (m_state != state::stopped)
@@ -39,9 +39,6 @@ bool controller::init(config cfg)
     // Create a worker thread to run the boost::asio::io_context.
     // The work guard is used to prevent the io_context::run() from returning if there's no work scheduled.
     m_workguard = std::make_unique<workguard_t>(boost::asio::make_work_guard(*m_io_ctx));
-
-    // Grab the config
-    after_init(std::move(cfg));
 
     return true;
 }

--- a/lib/malloy/core/controller.cpp
+++ b/lib/malloy/core/controller.cpp
@@ -32,8 +32,6 @@ bool controller::init(config cfg)
         return false;
     }
 
-    // Grab the config
-    m_cfg = std::move(cfg);
 
     // Create the I/O context
     m_io_ctx = std::make_shared<boost::asio::io_context>();
@@ -41,6 +39,9 @@ bool controller::init(config cfg)
     // Create a worker thread to run the boost::asio::io_context.
     // The work guard is used to prevent the io_context::run() from returning if there's no work scheduled.
     m_workguard = std::make_unique<workguard_t>(boost::asio::make_work_guard(*m_io_ctx));
+
+    // Grab the config
+    after_init(std::move(cfg));
 
     return true;
 }

--- a/lib/malloy/core/controller.hpp
+++ b/lib/malloy/core/controller.hpp
@@ -42,7 +42,6 @@ namespace malloy
         virtual ~controller();
 
         [[nodiscard("init may fail")]]
-        virtual
         bool init(config cfg);
 
         /**
@@ -64,7 +63,7 @@ namespace malloy
         std::future<void> stop();
 
     protected:
-        config m_cfg;
+        virtual void after_init(config&& cfg) = 0;
 
         [[nodiscard]]
         boost::asio::io_context&

--- a/lib/malloy/core/controller.hpp
+++ b/lib/malloy/core/controller.hpp
@@ -42,14 +42,6 @@ namespace malloy
         virtual ~controller();
 
 
-        /**
-         * Start the server. This function will not return until the server is stopped.
-         *
-         * @return Whether starting the server was successful.
-         */
-        [[nodiscard("start may fail")]]
-        virtual
-        bool start();
 
         /**
          * Stop the server.
@@ -70,6 +62,9 @@ namespace malloy
         {
             return *m_io_ctx;
         }
+        [[nodiscard("start may fail")]]
+        auto root_start(const config& cfg) -> bool;
+
 
         void remove_workguard() const;
 

--- a/lib/malloy/core/controller.hpp
+++ b/lib/malloy/core/controller.hpp
@@ -41,8 +41,6 @@ namespace malloy
         controller() = default;
         virtual ~controller();
 
-        [[nodiscard("init may fail")]]
-        bool init(config cfg);
 
         /**
          * Start the server. This function will not return until the server is stopped.
@@ -63,7 +61,8 @@ namespace malloy
         std::future<void> stop();
 
     protected:
-        virtual void after_init(config&& cfg) = 0;
+        [[nodiscard("init may fail")]]
+        bool init(const config& cfg);
 
         [[nodiscard]]
         boost::asio::io_context&

--- a/lib/malloy/core/http/utils.hpp
+++ b/lib/malloy/core/http/utils.hpp
@@ -22,6 +22,12 @@ namespace malloy::http
     {
         head.target(head.target().substr(resource.size()));
     }
+
+    template<bool isReq, typename Fields>
+    auto has_field(const boost::beast::http::header<isReq, Fields>& head, malloy::http::field check) -> bool
+    {
+        return head.find(check) != head.end();
+    }
 }
 
 

--- a/lib/malloy/core/http/utils.hpp
+++ b/lib/malloy/core/http/utils.hpp
@@ -24,7 +24,7 @@ namespace malloy::http
     }
 
     template<bool isReq, typename Fields>
-    auto has_field(const boost::beast::http::header<isReq, Fields>& head, malloy::http::field check) -> bool
+    auto has_field(const boost::beast::http::header<isReq, Fields>& head, const malloy::http::field check) -> bool
     {
         return head.find(check) != head.end();
     }

--- a/lib/malloy/core/websocket/connection.hpp
+++ b/lib/malloy/core/websocket/connection.hpp
@@ -18,20 +18,6 @@
 
 namespace malloy::websocket
 {
-    namespace detail
-    {
-        constexpr std::string_view beast_version = BOOST_BEAST_VERSION_STRING;
-        template<bool isClient>
-        constexpr auto ws_agent_string() -> std::string_view
-        {
-            if (isClient) {
-                return {BOOST_BEAST_VERSION_STRING " websocket-client-async"};
-            } else {
-                return {BOOST_BEAST_VERSION_STRING " malloy"};
-            }
-        }
-    }    // namespace detail
-
     /**
      * @class connection
      * @tparam isClient: Whether it is the client end of a websocket connection

--- a/lib/malloy/server/controller.cpp
+++ b/lib/malloy/server/controller.cpp
@@ -11,12 +11,16 @@
 
 using namespace malloy::server;
 
-void controller::after_init(config&& cfg) {
+auto controller::init(config cfg) -> bool {
+    if (!malloy::controller::init(cfg)) {
+        return false;
+    }
     // Grab the config
     m_cfg = std::move(cfg);
 
     // Create the top-level router
     m_router = std::make_shared<malloy::server::router>(m_cfg.logger->clone("router"));
+    return true;
 }
 
 #if MALLOY_FEATURE_TLS

--- a/lib/malloy/server/controller.cpp
+++ b/lib/malloy/server/controller.cpp
@@ -19,7 +19,7 @@ auto controller::init(config cfg) -> bool {
     m_cfg = std::move(cfg);
 
     // Create the top-level router
-    m_router = std::make_shared<malloy::server::router>(m_cfg.logger->clone("router"), m_cfg.ws_agent_string);
+    m_router = std::make_shared<malloy::server::router>(m_cfg.logger->clone("router"), m_cfg.agent_string);
     return true;
 }
 
@@ -66,8 +66,7 @@ bool controller::start()
         boost::asio::ip::tcp::endpoint{ boost::asio::ip::make_address(m_cfg.interface), m_cfg.port },
         m_router,
         std::make_shared<std::filesystem::path>(m_cfg.doc_root),
-        m_cfg.ws_agent_string
-    );
+        m_cfg.agent_string);
 
     // Run the listener
     m_listener->run();

--- a/lib/malloy/server/controller.cpp
+++ b/lib/malloy/server/controller.cpp
@@ -73,7 +73,7 @@ bool controller::start()
     m_listener->run();
 
     // Base class
-    if (!malloy::controller::start())
+    if (!root_start(m_cfg))
         return false;
 
     return true;

--- a/lib/malloy/server/controller.cpp
+++ b/lib/malloy/server/controller.cpp
@@ -11,19 +11,12 @@
 
 using namespace malloy::server;
 
-bool controller::init(config cfg)
-{
-    // Base class
-    if (!malloy::controller::init(cfg))
-        return false;
-
+void controller::after_init(config&& cfg) {
     // Grab the config
     m_cfg = std::move(cfg);
 
     // Create the top-level router
     m_router = std::make_shared<malloy::server::router>(m_cfg.logger->clone("router"));
-
-    return true;
 }
 
 #if MALLOY_FEATURE_TLS

--- a/lib/malloy/server/controller.cpp
+++ b/lib/malloy/server/controller.cpp
@@ -65,7 +65,8 @@ bool controller::start()
         m_tls_ctx,
         boost::asio::ip::tcp::endpoint{ boost::asio::ip::make_address(m_cfg.interface), m_cfg.port },
         m_router,
-        std::make_shared<std::filesystem::path>(m_cfg.doc_root)
+        std::make_shared<std::filesystem::path>(m_cfg.doc_root),
+        m_cfg.ws_agent_string
     );
 
     // Run the listener

--- a/lib/malloy/server/controller.cpp
+++ b/lib/malloy/server/controller.cpp
@@ -19,7 +19,7 @@ auto controller::init(config cfg) -> bool {
     m_cfg = std::move(cfg);
 
     // Create the top-level router
-    m_router = std::make_shared<malloy::server::router>(m_cfg.logger->clone("router"));
+    m_router = std::make_shared<malloy::server::router>(m_cfg.logger->clone("router"), m_cfg.ws_agent_string);
     return true;
 }
 

--- a/lib/malloy/server/controller.hpp
+++ b/lib/malloy/server/controller.hpp
@@ -56,7 +56,7 @@ namespace malloy::server
             /**
              * @brief Agent string used for websocket connections
              */
-            std::string agent_string{BOOST_BEAST_VERSION_STRING " malloy-server"};
+            std::string agent_string{"malloy-server"};
         };
 
         controller() = default;

--- a/lib/malloy/server/controller.hpp
+++ b/lib/malloy/server/controller.hpp
@@ -2,6 +2,8 @@
 
 #include "../core/controller.hpp"
 
+#include <boost/beast/version.hpp>
+
 #include <memory>
 #include <filesystem>
 #include <string>
@@ -81,7 +83,7 @@ namespace malloy::server
          *
          * @return Whether starting the server was successful.
          */
-        bool start() override;
+        bool start();
 
         #if MALLOY_FEATURE_TLS
             /**

--- a/lib/malloy/server/controller.hpp
+++ b/lib/malloy/server/controller.hpp
@@ -102,6 +102,8 @@ namespace malloy::server
         {
             return m_router;
         }
+    protected:
+        void after_init(config&& cfg);
 
     private:
         config m_cfg;

--- a/lib/malloy/server/controller.hpp
+++ b/lib/malloy/server/controller.hpp
@@ -56,7 +56,7 @@ namespace malloy::server
             /**
              * @brief Agent string used for websocket connections
              */
-            std::string ws_agent_string{BOOST_BEAST_VERSION_STRING " malloy-server"};
+            std::string agent_string{BOOST_BEAST_VERSION_STRING " malloy-server"};
         };
 
         controller() = default;

--- a/lib/malloy/server/controller.hpp
+++ b/lib/malloy/server/controller.hpp
@@ -2,7 +2,6 @@
 
 #include "../core/controller.hpp"
 
-#include <boost/beast/version.hpp>
 
 #include <memory>
 #include <filesystem>
@@ -54,7 +53,8 @@ namespace malloy::server
             std::filesystem::path doc_root = ".";
 
             /**
-             * @brief Agent string used for websocket connections
+             * @brief Agent string used for connections
+             * @details Set as the Server field in http headers
              */
             std::string agent_string{"malloy-server"};
         };

--- a/lib/malloy/server/controller.hpp
+++ b/lib/malloy/server/controller.hpp
@@ -50,6 +50,11 @@ namespace malloy::server
              * to the working directory.
              */
             std::filesystem::path doc_root = ".";
+
+            /**
+             * @brief Agent string used for websocket connections
+             */
+            std::string ws_agent_string{BOOST_BEAST_VERSION_STRING " malloy-server"};
         };
 
         controller() = default;
@@ -68,6 +73,7 @@ namespace malloy::server
          * @param cfg The configuration to use.
          * @return Whether the initialization was successful.
          */
+         [[nodiscard("init may fail")]]
         bool init(config cfg);
 
         /**
@@ -102,8 +108,6 @@ namespace malloy::server
         {
             return m_router;
         }
-    protected:
-        void after_init(config&& cfg);
 
     private:
         config m_cfg;

--- a/lib/malloy/server/http/connection.hpp
+++ b/lib/malloy/server/http/connection.hpp
@@ -107,6 +107,7 @@ namespace malloy::server::http
         struct config
         {
             std::uint64_t request_body_limit = 10 * 10e6;   ///< The maximum allowed body request size in bytes.
+            std::string agent_string; ///< Agent string to use, set by the controller
         };
 
         /**
@@ -249,7 +250,7 @@ namespace malloy::server::http
                 // of both the socket and the HTTP request.
                 auto ws_connection = server::websocket::connection::make(
                     m_logger->clone("websocket_connection"),
-                    malloy::websocket::stream{derived().release_stream()});
+                    malloy::websocket::stream{derived().release_stream()}, cfg.agent_string);
                 m_router->websocket(*m_doc_root, gen, ws_connection);
 
 

--- a/lib/malloy/server/http/connection_detector.hpp
+++ b/lib/malloy/server/http/connection_detector.hpp
@@ -44,7 +44,8 @@ namespace malloy::server::http
             boost::asio::ip::tcp::socket&& socket,
             std::shared_ptr<boost::asio::ssl::context> ctx,
             std::shared_ptr<const std::filesystem::path> doc_root,
-            std::shared_ptr<malloy::server::router> router
+            std::shared_ptr<malloy::server::router> router,
+            std::string agent_string
         );
 
         /**
@@ -59,6 +60,7 @@ namespace malloy::server::http
         boost::beast::flat_buffer m_buffer;
         std::shared_ptr<const std::filesystem::path> m_doc_root;
         std::shared_ptr<malloy::server::router> m_router;
+        std::string m_agent_string;
 
         void on_detect(boost::beast::error_code ec, bool result);
     };

--- a/lib/malloy/server/listener.cpp
+++ b/lib/malloy/server/listener.cpp
@@ -13,14 +13,16 @@ listener::listener(
     std::shared_ptr<boost::asio::ssl::context> tls_ctx,
     const boost::asio::ip::tcp::endpoint& endpoint,
     std::shared_ptr<server::router> router,
-    std::shared_ptr<const std::filesystem::path> http_doc_root
+    std::shared_ptr<const std::filesystem::path> http_doc_root,
+    std::string agent_string
 ) :
     m_logger(std::move(logger)),
     m_io_ctx(ioc),
     m_tls_ctx(std::move(tls_ctx)),
     m_acceptor(boost::asio::make_strand(ioc)),
     m_router(std::move(router)),
-    m_doc_root(std::move(http_doc_root))
+    m_doc_root(std::move(http_doc_root)),
+    m_agent_string{std::move(agent_string)}
 {
     boost::beast::error_code ec;
 
@@ -113,7 +115,8 @@ void listener::on_accept(boost::beast::error_code ec, boost::asio::ip::tcp::sock
         std::move(socket),
         m_tls_ctx,
         m_doc_root,
-        m_router
+        m_router,
+        m_agent_string
     );
 
     // Run the HTTP connection

--- a/lib/malloy/server/listener.hpp
+++ b/lib/malloy/server/listener.hpp
@@ -49,7 +49,8 @@ namespace malloy::server
             std::shared_ptr<boost::asio::ssl::context> tls_ctx,
             const boost::asio::ip::tcp::endpoint& endpoint,
             std::shared_ptr<malloy::server::router> router,
-            std::shared_ptr<const std::filesystem::path> http_doc_root
+            std::shared_ptr<const std::filesystem::path> http_doc_root,
+            std::string agent_string
         );
 
         /**
@@ -106,6 +107,7 @@ namespace malloy::server
         boost::asio::ip::tcp::acceptor m_acceptor;
         std::shared_ptr<malloy::server::router> m_router;
         std::shared_ptr<const std::filesystem::path> m_doc_root;
+        std::string m_agent_string;
 
         /**
          * Start accepting incoming requests.

--- a/lib/malloy/server/routing/router.cpp
+++ b/lib/malloy/server/routing/router.cpp
@@ -7,8 +7,8 @@
 
 using namespace malloy::server;
 
-router::router(std::shared_ptr<spdlog::logger> logger) :
-    m_logger(std::move(logger))
+router::router(std::shared_ptr<spdlog::logger> logger, std::string server_str) :
+    m_logger(std::move(logger)), m_server_str{std::move(server_str)}
 {
 }
 
@@ -131,9 +131,7 @@ bool router::add_file_serving(std::string resource, std::filesystem::path storag
 
     ep->resource_base = resource;
     ep->base_path = std::move(storage_base_path);
-    ep->writer = [](const auto& req, auto&& resp, const auto& conn) {
-        std::visit([&](auto&& resp) { detail::send_response(req, std::move(resp), conn); }, std::move(resp));
-    };
+    ep->writer = make_endpt_writer_callback();
 
     // Add
     return add_http_endpoint(std::move(ep));

--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -73,12 +73,12 @@ namespace malloy::server
          * @param connection The connection.
          */
         template<typename Body>
-        void send_response(const boost::beast::http::request_header<>& req, malloy::http::response<Body>&& resp, http::connection_t connection)
+        void send_response(const boost::beast::http::request_header<>& req, malloy::http::response<Body>&& resp, http::connection_t connection, std::string_view server_str)
         {
             // Add more information to the response
             //resp.keep_alive(req.keep_alive); // TODO: Is this needed?, if so its a spanner in the works
             resp.version(req.version());
-            resp.set(boost::beast::http::field::server, BOOST_BEAST_VERSION_STRING);
+            resp.set(boost::beast::http::field::server, server_str);
             resp.prepare_payload();
 
             std::visit([resp = std::move(resp)](auto& c) mutable {
@@ -127,7 +127,7 @@ namespace malloy::server
          *
          * @param logger The logger instance to use.
          */
-        explicit router(std::shared_ptr<spdlog::logger> logger);
+        router(std::shared_ptr<spdlog::logger> logger, std::string server_str);
 
         /**
          * Copy constructor.
@@ -329,7 +329,7 @@ namespace malloy::server
                 auto resp = ep->handle(req, connection);
                 if (resp) {
                     // Send the response
-                    detail::send_response(req->header(), std::move(*resp), connection);
+                    detail::send_response(req->header(), std::move(*resp), connection, m_server_str);
                 }
 
                 // We're done handling this request
@@ -337,7 +337,7 @@ namespace malloy::server
             }
 
             // If we end up where we have no meaningful way of handling this request
-            detail::send_response(req->header(), malloy::http::generator::bad_request("unknown request"), connection);
+            detail::send_response(req->header(), malloy::http::generator::bad_request("unknown request"), connection, m_server_str);
         }
 
         /**
@@ -385,6 +385,14 @@ namespace malloy::server
         std::unordered_map<std::string, std::shared_ptr<router>> m_sub_routers;
         std::vector<std::shared_ptr<endpoint_http>> m_endpoints_http;
         std::vector<std::shared_ptr<endpoint_websocket>> m_endpoints_websocket;
+        std::string m_server_str{BOOST_BEAST_VERSION_STRING};
+
+        /// Create the lambda wrapped callback for the writer
+        auto make_endpt_writer_callback() {
+            return [this]<typename R>(const auto& req, R&& resp, const auto& conn) {
+              std::visit([&, this]<typename Re>(Re&& resp) { detail::send_response(req, std::forward<Re>(resp), conn, m_server_str); }, std::forward<R>(resp));
+            };
+        }
 
         template<
             bool UsesCaptures,
@@ -432,9 +440,7 @@ namespace malloy::server
                 return false;
             }
 
-            ep->writer = [this](const auto& req, auto&& resp, const auto& conn) {
-                std::visit([&, this](auto&& resp) { detail::send_response(req, std::move(resp), conn); }, std::move(resp));
-            };
+            ep->writer = make_endpt_writer_callback();
 
             // Add route
             return add_http_endpoint(std::move(ep));

--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -78,7 +78,9 @@ namespace malloy::server
             // Add more information to the response
             //resp.keep_alive(req.keep_alive); // TODO: Is this needed?, if so its a spanner in the works
             resp.version(req.version());
-            resp.set(boost::beast::http::field::server, server_str);
+            if (!malloy::http::has_field(resp, malloy::http::field::server)) {
+                resp.set(boost::beast::http::field::server, server_str);
+            }
             resp.prepare_payload();
 
             std::visit([resp = std::move(resp)](auto& c) mutable {

--- a/test/test_suites/components/CMakeLists.txt
+++ b/test/test_suites/components/CMakeLists.txt
@@ -8,4 +8,5 @@ target_sources(
         request.cpp
         websockets.cpp
         stream.cpp
+        controller.cpp
 )

--- a/test/test_suites/components/controller.cpp
+++ b/test/test_suites/components/controller.cpp
@@ -8,7 +8,7 @@ namespace mc = malloy::client;
 namespace ms = malloy::server;
 
 TEST_SUITE("controller - roundtrips") {
-    TEST_CASE("Server and client set agent strings based on ws_agent_string") {
+    TEST_CASE("Server and client set agent strings based on user_agent") {
         constexpr auto cli_agent_str = "test-cli";
         constexpr auto serve_agent_str = "test-serve";
         constexpr auto addr = "127.0.0.1";
@@ -21,8 +21,8 @@ TEST_SUITE("controller - roundtrips") {
         mc::controller::config cli_cfg{general_cfg};
         ms::controller::config serve_cfg{general_cfg};
 
-        cli_cfg.ws_agent_string = cli_agent_str;
-        serve_cfg.ws_agent_string = serve_agent_str;
+        cli_cfg.user_agent = cli_agent_str;
+        serve_cfg.agent_string = serve_agent_str;
         serve_cfg.interface = addr;
         serve_cfg.port = port;
 

--- a/test/test_suites/components/controller.cpp
+++ b/test/test_suites/components/controller.cpp
@@ -1,0 +1,59 @@
+#include "../../test.hpp"
+
+#include <malloy/server/controller.hpp>
+#include <malloy/server/routing/router.hpp>
+#include <malloy/client/controller.hpp>
+
+namespace mc = malloy::client;
+namespace ms = malloy::server;
+
+TEST_SUITE("controller - roundtrips") {
+    TEST_CASE("Server and client set agent strings based on ws_agent_string") {
+        constexpr auto cli_agent_str = "test-cli";
+        constexpr auto serve_agent_str = "test-serve";
+        constexpr auto addr = "127.0.0.1";
+        constexpr uint16_t port = 55123;
+
+
+        malloy::controller::config general_cfg;
+        general_cfg.logger = spdlog::default_logger();
+
+        mc::controller::config cli_cfg{general_cfg};
+        ms::controller::config serve_cfg{general_cfg};
+
+        cli_cfg.ws_agent_string = cli_agent_str;
+        serve_cfg.ws_agent_string = serve_agent_str;
+        serve_cfg.interface = addr;
+        serve_cfg.port = port;
+
+        mc::controller cli_ctrl;
+
+        REQUIRE(cli_ctrl.init(cli_cfg));
+
+        malloy::http::request<> req{
+            malloy::http::method::get,
+            addr,
+            port,
+            "/"
+        };
+        auto stop_tkn = cli_ctrl.http_request(req, [&](auto&& resp){
+            CHECK(resp[malloy::http::field::server] == serve_agent_str);
+        });
+
+        ms::controller serve_ctrl;
+
+        REQUIRE(serve_ctrl.init(serve_cfg));
+
+        serve_ctrl.router()->add(malloy::http::method::get, "/", [&](auto&& req){
+            CHECK(req[malloy::http::field::user_agent] == cli_agent_str);
+            return malloy::http::generator::ok();
+        });
+
+        REQUIRE(serve_ctrl.start());
+        REQUIRE(cli_ctrl.run());
+
+        CHECK(!stop_tkn.get());
+
+    }
+}
+

--- a/test/test_suites/components/websockets.cpp
+++ b/test/test_suites/components/websockets.cpp
@@ -89,8 +89,10 @@ namespace
 		server_cfg.interface = "127.0.0.1";
 		server_cfg.port = port;
 
+        mc::controller::config cli_cfg{general_cfg};
+
 		REQUIRE(s_ctrl.init(server_cfg));
-		REQUIRE(c_ctrl.init(general_cfg));
+		REQUIRE(c_ctrl.init(cli_cfg));
 
         setup_server(s_ctrl);
         setup_client(c_ctrl);


### PR DESCRIPTION
This implements #37. There are a few issues that cropped up during implementation.

## Main Changes 
- `malloy::controller` has had its `m_cfg` removed. This was due to collisions with derived versions and it was just a whole mess. I hacked around it rather while doing #35, but I gave up when I realised that `init` is hiding the inherited version to take the right `config`. I can reverse it but I'd rather not :p 
- `malloy::controller` has had parts of its interface made `protected` since it no longer has `m_cfg`. If anything relied on the controller `start` or `init` it will be broken by this patch
- `server::controller::config` and `client::controller::config` both have new `ws_agent_string` fields, which default to `<beast version> malloy-<server|client>`
- The `agent_string` is threaded through the server and client side and set as the decorator on the websocket connection
- `client::controller::init` now takes a `client::controller::config`, which will break code currently passing `malloy::controller::config` to it

The tests don't fail, but an error is logged in `on_read` in `server::http::connection`. I'm not really sure if it indicates a problem or not, as far as I can tell from testing the examples everything seems to be OK but I may have missed something.


Closes: #37 