### PR TITLE
Concept improvements

### DIFF
--- a/lib/malloy/client/type_traits.hpp
+++ b/lib/malloy/client/type_traits.hpp
@@ -55,7 +55,7 @@ namespace malloy::client::concepts
     {
         {
             f.body_for(h)
-            } -> malloy::concepts::is_variant;
+            } -> malloy::concepts::is_variant_of_bodies;
         {
             std::visit(detail::response_filter_body_helper<F>{}, f.body_for(h))};
     };

--- a/lib/malloy/core/type_traits.hpp
+++ b/lib/malloy/core/type_traits.hpp
@@ -25,6 +25,8 @@ namespace malloy::concepts
             void operator()(const T<Ts...>&) const {}
         };
 
+
+
     }    // namespace detail
 
     template<typename T, template<typename...> typename A>
@@ -46,6 +48,20 @@ namespace malloy::concepts
 
     template<typename V>
     concept is_variant = is<V, std::variant>;
+
+    namespace detail {
+        template<template<typename...> typename V, template<typename...> typename A>
+        struct is_container_of_helper {
+            template<is<V>... Ts>
+            void operator()(const A<Ts...>&) const {}
+        };
+    }
+
+    template<typename T, template<typename...> typename V, template<typename...> typename Other>
+    concept is_container_of = requires(const T& v, const detail::is_container_of_helper<V, Other>& h) {
+        h(v);
+    };
+    static_assert(is_container_of<std::variant<std::tuple<std::string>, std::tuple<int>>, std::tuple, std::variant>, "is_container_of is defective");
 
 }    // namespace malloy::concepts
 /** 

--- a/lib/malloy/core/type_traits.hpp
+++ b/lib/malloy/core/type_traits.hpp
@@ -93,7 +93,7 @@ namespace malloy::concepts
     }
 
     template<typename T, template<typename...> typename Contained, template<typename...> typename Container>
-    concept is_container_of = is_container_of_if<T, Container, typename detail::is_a<Contained>::type>;
+    concept is_container_of = is_container_of_if<T, Container, detail::is_a<Contained>::template type>;
 
     template<typename T>
     concept is_variant_of_bodies = is_container_of_if<T, std::variant, boost::beast::http::is_body>;

--- a/lib/malloy/core/type_traits.hpp
+++ b/lib/malloy/core/type_traits.hpp
@@ -12,11 +12,25 @@ namespace malloy::concepts
 {
     namespace detail
     {
-        struct is_variant_helper {
+        /**
+         * @brief Helper for the is<...> concept.
+         * @details Essentially an expanded lambda []<typename... Ts>(const T<Ts..>&){}
+         * @note Needed for clang 12 support
+         * @tparam T The type to check against
+         */
+        template<template<typename...> typename T>
+        struct is_helper
+        {
             template<typename... Ts>
-            void operator()(const std::variant<Ts...>&) const {};
+            void operator()(const T<Ts...>&) const {}
         };
+
     }    // namespace detail
+
+    template<typename T, template<typename...> typename A>
+    concept is = requires(const T& t, const detail::is_helper<A>& h) {
+        h(t);
+    };
 
     template<typename B>
     concept const_buffer_sequence = boost::asio::is_const_buffer_sequence<B>::value;
@@ -31,10 +45,7 @@ namespace malloy::concepts
     concept async_read_handler = std::invocable<Func, boost::beast::error_code, std::size_t>;
 
     template<typename V>
-    concept is_variant = requires(V v)
-    {
-        detail::is_variant_helper{}(v);
-    };
+    concept is_variant = is<V, std::variant>;
 
 }    // namespace malloy::concepts
 /** 

--- a/lib/malloy/server/routing/type_traits.hpp
+++ b/lib/malloy/server/routing/type_traits.hpp
@@ -9,9 +9,11 @@ namespace malloy::server::concepts
 {
     namespace detail
     {
+        template<typename T>
+        concept route_handler_retr = malloy::concepts::is_container_of<T, malloy::http::response, std::variant> || malloy::concepts::is<T, malloy::http::response>;
         template<typename Func, typename... Args>
         concept route_handler_helper = std::invocable<Func, Args...> && requires(Func f, Args... args) {
-            { std::invoke(f, args...) } -> malloy::concepts::is<malloy::http::response>;
+            { std::invoke(f, args...) } -> route_handler_retr;
         };
     }
 


### PR DESCRIPTION
This fixes #64. I still get a pretty unhelpful message from msvc simply saying "contraints not satisfied" but thats an issue with msvc imo, the information is now there for it to be more helpful if it wants.

I also got a little bit carried away once I realised I could generalise things a little. On the upside, some of the constraints on a `Filter` are now better defined (variant of types satisfying body for `body_for`)... but there is some possibly quite obscure TMP code needed to make it happen. 

~~I am currently waiting on [this SO question](https://stackoverflow.com/q/68363557/12448530) for the answer to why it currently doesn't build on non-msvc~~ should be fixed
