### PR TITLE
[Enhancement] Add option to build as shared libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,4 +130,4 @@ jobs:
         run: cmake --build build
 
       - name: Run tests
-        run: ./build/test/malloy-tests
+        run: ./build/bin/malloy-tests

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -72,4 +72,4 @@ jobs:
         run: cmake --build build
 
       - name: Run tests
-        run: ./build/test/malloy-tests
+        run: ./build/bin/malloy-tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,13 @@ option(MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD "Whether to automatically fetch spdlog"
 
 set(MALLOY_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin) # Needed for later
 
+
+if (MALLOY_BUILD_SHARED) 
+    set(MALLOY_LIBRARY_TYPE SHARED)
+else()
+    set(MALLOY_LIBRARY_TYPE STATIC)
+endif()
+
 # Set dependencies accordingly
 if (MALLOY_FEATURE_TLS)
     set(MALLOY_DEPENDENCY_OPENSSL ON)
@@ -43,13 +50,13 @@ message("")
 message("---------------------")
 message("Malloy configuration:")
 message("  Build:")
-message("    Examples : " ${MALLOY_BUILD_EXAMPLES})
-message("    Tests    : " ${MALLOY_BUILD_TESTS})
-message("    Shared   : " ${MALLOY_BUILD_SHARED})
+message("    Examples     : " ${MALLOY_BUILD_EXAMPLES})
+message("    Tests        : " ${MALLOY_BUILD_TESTS})
+message("    Library Type : " ${MALLOY_LIBRARY_TYPE})
 message("  Features:")
-message("    Client   : " ${MALLOY_FEATURE_CLIENT})
-message("    Server   : " ${MALLOY_FEATURE_SERVER})
-message("    HTML     : " ${MALLOY_FEATURE_HTML})
-message("    TLS      : " ${MALLOY_FEATURE_TLS})
+message("    Client       : " ${MALLOY_FEATURE_CLIENT})
+message("    Server       : " ${MALLOY_FEATURE_SERVER})
+message("    HTML         : " ${MALLOY_FEATURE_HTML})
+message("    TLS          : " ${MALLOY_FEATURE_TLS})
 message("---------------------")
 message("")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(
 )
 
 # Options
+option(MALLOY_BUILD_SHARED "Whether to build as a shared library" OFF)
 option(MALLOY_BUILD_EXAMPLES "Whether to build examples"       ON)
 option(MALLOY_BUILD_TESTS    "Whether to build tests"          ON)
 option(MALLOY_FEATURE_CLIENT "Whether to build the client"     ON)
@@ -41,6 +42,7 @@ message("Malloy configuration:")
 message("  Build:")
 message("    Examples : " ${MALLOY_BUILD_EXAMPLES})
 message("    Tests    : " ${MALLOY_BUILD_TESTS})
+message("    Shared   : " ${MALLOY_BUILD_SHARED})
 message("  Features:")
 message("    Client   : " ${MALLOY_FEATURE_CLIENT})
 message("    Server   : " ${MALLOY_FEATURE_SERVER})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ option(MALLOY_FEATURE_HTML   "Whether to enable HTML features" ON)
 option(MALLOY_FEATURE_TLS    "Whether to enable TLS features"  OFF)
 option(MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD "Whether to automatically fetch spdlog" ON)
 
+
+set(MALLOY_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin) # Needed for later
+
 # Set dependencies accordingly
 if (MALLOY_FEATURE_TLS)
     set(MALLOY_DEPENDENCY_OPENSSL ON)

--- a/examples/client/example.cmake
+++ b/examples/client/example.cmake
@@ -4,4 +4,6 @@ function(malloy_example_setup_client target)
         PRIVATE
             malloy-client
     )
+
+    set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${MALLOY_BINARY_DIR})
 endfunction()

--- a/examples/server/example.cmake
+++ b/examples/server/example.cmake
@@ -4,4 +4,6 @@ function(malloy_example_setup target)
         PRIVATE
             malloy-server
     )
+
+    set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${MALLOY_BINARY_DIR})
 endfunction()

--- a/lib/malloy/client/CMakeLists.txt
+++ b/lib/malloy/client/CMakeLists.txt
@@ -5,7 +5,7 @@ include("../target_setup.cmake")
 set(TARGET "malloy-client")
 
 # Create library
-malloy_add_library(${TARGET})
+add_library(${TARGET} ${MALLOY_LIBRARY_TYPE})
 
 # Apply common setup
 malloy_target_common_setup(${TARGET})

--- a/lib/malloy/client/CMakeLists.txt
+++ b/lib/malloy/client/CMakeLists.txt
@@ -5,7 +5,7 @@ include("../target_setup.cmake")
 set(TARGET "malloy-client")
 
 # Create library
-add_library(${TARGET} STATIC)
+malloy_add_library(${TARGET})
 
 # Apply common setup
 malloy_target_common_setup(${TARGET})

--- a/lib/malloy/core/CMakeLists.txt
+++ b/lib/malloy/core/CMakeLists.txt
@@ -5,7 +5,7 @@ include(../target_setup.cmake)
 set(TARGET "malloy-core")
 
 # Create library
-malloy_add_library(${TARGET})
+add_library(${TARGET} ${MALLOY_LIBRARY_TYPE})
 
 # Apply common setup
 malloy_target_common_setup(${TARGET})

--- a/lib/malloy/core/CMakeLists.txt
+++ b/lib/malloy/core/CMakeLists.txt
@@ -5,7 +5,7 @@ include(../target_setup.cmake)
 set(TARGET "malloy-core")
 
 # Create library
-add_library(${TARGET} STATIC)
+malloy_add_library(${TARGET})
 
 # Apply common setup
 malloy_target_common_setup(${TARGET})

--- a/lib/malloy/server/CMakeLists.txt
+++ b/lib/malloy/server/CMakeLists.txt
@@ -5,7 +5,7 @@ include(../target_setup.cmake)
 set(TARGET "malloy-server")
 
 # Create library
-malloy_add_library(${TARGET})
+add_library(${TARGET} ${MALLOY_LIBRARY_TYPE})
 
 
 # Apply common setup

--- a/lib/malloy/server/CMakeLists.txt
+++ b/lib/malloy/server/CMakeLists.txt
@@ -5,7 +5,8 @@ include(../target_setup.cmake)
 set(TARGET "malloy-server")
 
 # Create library
-add_library(${TARGET} STATIC)
+malloy_add_library(${TARGET})
+
 
 # Apply common setup
 malloy_target_common_setup(${TARGET})

--- a/lib/malloy/target_setup.cmake
+++ b/lib/malloy/target_setup.cmake
@@ -1,3 +1,12 @@
+function(malloy_add_library NAME) # We can't use generator expressions for SHARED or STATIC
+    if (MALLOY_BUILD_SHARED) 
+        add_library(${NAME} SHARED)
+    else()
+        add_library(${NAME} STATIC)
+    endif()
+
+endfunction()
+
 function(malloy_target_common_setup TARGET)
     target_compile_features(
         ${TARGET}

--- a/lib/malloy/target_setup.cmake
+++ b/lib/malloy/target_setup.cmake
@@ -72,4 +72,10 @@ function(malloy_target_common_setup TARGET)
             $<$<BOOL:${WIN32}>:wsock32>
             $<$<BOOL:${WIN32}>:ws2_32>
     )
+    set_target_properties(
+        ${TARGET} 
+        PROPERTIES 
+            RUNTIME_OUTPUT_DIRECTORY ${MALLOY_BINARY_DIR} 
+            LIBRARY_OUTPUT_DIRECTORY ${MALLOY_BINARY_DIR}
+    )
 endfunction()

--- a/lib/malloy/target_setup.cmake
+++ b/lib/malloy/target_setup.cmake
@@ -1,12 +1,3 @@
-function(malloy_add_library NAME) # We can't use generator expressions for SHARED or STATIC
-    if (MALLOY_BUILD_SHARED) 
-        add_library(${NAME} SHARED)
-    else()
-        add_library(${NAME} STATIC)
-    endif()
-
-endfunction()
-
 function(malloy_target_common_setup TARGET)
     target_compile_features(
         ${TARGET}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,3 +36,6 @@ add_test(
     NAME doctest
     COMMAND ${TARGET}
 )
+
+set_target_properties(${TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${MALLOY_BINARY_DIR})
+


### PR DESCRIPTION
This add the option `MALLOY_BUILD_SHARED`, which causes all libraries to be build as their shared versions (`.dll` on windows, `.so` on linux, etc). Since generator expressions cannot be used for `add_library(.. [SHARED|STATIC])` I used an if statement and put it in a function (`malloy_add_library`). 

Additionally, all shared libraries and binaries are now place in `<builddir>/bin` so stuff will actually run under windows. This is set on a per-target basis to avoid leaking into consumer builds. I think it is better to do this across the board rather than special case windows + shared configuration, since that introduces possible confusion and additional complexity. I am happy to change this though.

As discussed in #55 there might be issues with linking on windows, the CI seems to be fine though so hopefully its no longer a thing.


Closes: #55 