### PR TITLE
Fix shared build + downloaded spdlog (on linux)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         boost_version: [1.74.0, 1.75.0, 1.76.0]
-        shared: [ON, OFF]
+        #shared: [ON, OFF]
         toolchain:
           [
             {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         boost_version: [1.74.0, 1.75.0, 1.76.0]
+        shared: [ON, OFF]
         toolchain:
           [
             {
@@ -74,7 +75,7 @@ jobs:
       CC: ${{ matrix.toolchain.cc }}
       CXX: ${{ matrix.toolchain.cxx }}
 
-    name: "${{ matrix.toolchain.name }} (boost v${{ matrix.boost_version }})"
+    name: "${{ matrix.toolchain.name }} (boost v${{ matrix.boost_version }}) (shared: ${{ matrix.shared }})"
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
       - uses: actions/checkout@v2
@@ -124,7 +125,7 @@ jobs:
         uses: ilammy/msvc-dev-cmd@v1
 
       - name: Configure
-        run: cmake -Bbuild -GNinja -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.toolchain.tls }}
+        run: cmake -Bbuild -GNinja -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.toolchain.tls }} -DMALLOY_BUILD_SHARED=${{ matrix.shared }}
 
       - name: Build
         run: cmake --build build

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -15,13 +15,14 @@ jobs:
       fail-fast: false
       matrix:
         boost_version: [1.76.0]
+        shared: [ON, OFF]
         malloy_tls: [ON, OFF]
 
     runs-on: windows-latest
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost-${{ matrix.boost_version }}
 
-    name: "msys2/clang (boost v${{ matrix.boost_version }}) (tls: ${{ matrix.malloy_tls }})"
+    name: "msys2/clang (boost v${{ matrix.boost_version }}) (tls: ${{ matrix.malloy_tls }}) (shared: ${{ matrix.shared }})"
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     defaults:
       run:
@@ -66,7 +67,7 @@ jobs:
           rm -rf boost_*/* download.tar.bz2 download.tar
 
       - name: Configure
-        run: cmake -Bbuild -G"MSYS Makefiles" -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.malloy_tls }} -DMALLOY_DEPENDENCY_SPDLOG_DOWNLOAD=ON
+        run: cmake -Bbuild -G"MSYS Makefiles" -DMALLOY_BUILD_EXAMPLES=ON -DMALLOY_BUILD_TESTS=ON -DMALLOY_FEATURE_TLS=${{ matrix.malloy_tls }} -DMALLOY_DEPENDENCY_SPDLOG_DOWNLOAD=ON -DMALLOY_BUILD_SHARED=${{ matrix.shared }}
 
       - name: Build
         run: cmake --build build

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         boost_version: [1.76.0]
-        shared: [ON, OFF]
+        #shared: [ON, OFF]
         malloy_tls: [ON, OFF]
 
     runs-on: windows-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ option(MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD "Whether to automatically fetch spdlog"
 
 set(MALLOY_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin) # Needed for later
 
-
 # Set library type to build
 if (MALLOY_BUILD_SHARED) 
     set(MALLOY_LIBRARY_TYPE SHARED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ option(MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD "Whether to automatically fetch spdlog"
 
 set(MALLOY_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin) # Needed for later
 
+
 # Set library type to build
 if (MALLOY_BUILD_SHARED) 
     set(MALLOY_LIBRARY_TYPE SHARED)

--- a/lib/malloy/core/external.cmake
+++ b/lib/malloy/core/external.cmake
@@ -13,6 +13,7 @@ find_package(
 # spdlog
 ########################################################################################################################
 if (MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD)
+
     FetchContent_Declare(
         spdlog
         GIT_REPOSITORY https://github.com/gabime/spdlog
@@ -21,7 +22,7 @@ if (MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD)
     FetchContent_GetProperties(spdlog)
     if (NOT spdlog_POPULATED) 
         FetchContent_Populate(spdlog)
-        set(SPDLOG_BUILD_SHARED ${MALLOY_BUILD_SHARED})
+        set(SPDLOG_BUILD_SHARED ${MALLOY_BUILD_SHARED} CACHE INTERNAL "")
 
         add_subdirectory(${spdlog_SOURCE_DIR} ${spdlog_BINARY_DIR})
     endif()

--- a/lib/malloy/core/external.cmake
+++ b/lib/malloy/core/external.cmake
@@ -18,7 +18,13 @@ if (MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD)
         GIT_REPOSITORY https://github.com/gabime/spdlog
         GIT_TAG        v1.8.3
     )
-    FetchContent_MakeAvailable(spdlog)
+    FetchContent_GetProperties(spdlog)
+    if (NOT spdlog_POPULATED) 
+        FetchContent_Populate(spdlog)
+        set(SPDLOG_BUILD_SHARED ${MALLOY_BUILD_SHARED})
+
+        add_subdirectory(${spdlog_SOURCE_DIR} ${spdlog_BINARY_DIR})
+    endif()
 else()
     find_package(spdlog REQUIRED)
 endif()

--- a/lib/malloy/core/external.cmake
+++ b/lib/malloy/core/external.cmake
@@ -13,7 +13,6 @@ find_package(
 # spdlog
 ########################################################################################################################
 if (MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD)
-
     FetchContent_Declare(
         spdlog
         GIT_REPOSITORY https://github.com/gabime/spdlog


### PR DESCRIPTION
This fixes the shared library + downloaded spdlog configuration (which runs into link errors otherwise). The problem was that `MALLOY_BUILD_SHARED` was not propagated to `spdlog`. Unfortunately I didn't catch this because I use external spdlog + conan for my local linux environment and didn't add the shared config to the CI.

This patch also adds the shared config to the CI, however it is disabled until #55 is resolved (since it won't build on msvc until then)