### PR TITLE
Add fmt as full dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(MALLOY_FEATURE_SERVER "Whether to build the server"     ON)
 option(MALLOY_FEATURE_HTML   "Whether to enable HTML features" ON)
 option(MALLOY_FEATURE_TLS    "Whether to enable TLS features"  OFF)
 option(MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD "Whether to automatically fetch spdlog" ON)
+option(MALLOY_DEPENDENCY_FMT_DOWNLOAD "Whether to automatically fetch fmt" ON)
 
 set(MALLOY_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/bin) # Needed for later
 

--- a/examples/ws_handlers.hpp
+++ b/examples/ws_handlers.hpp
@@ -4,7 +4,8 @@
 #include <malloy/core/http/request.hpp>
 #include <malloy/core/error.hpp>
 #include <malloy/core/websocket/connection.hpp>
-#include <spdlog/fmt/fmt.h>
+
+#include <fmt/format.h>
 
 #include <thread>
 

--- a/lib/malloy/client/controller.cpp
+++ b/lib/malloy/client/controller.cpp
@@ -5,6 +5,8 @@
     #include <boost/certify/https_verification.hpp>
 #endif
 
+#include <fmt/format.h>
+
 using namespace malloy::client;
 
 namespace fs = std::filesystem;

--- a/lib/malloy/core/external.cmake
+++ b/lib/malloy/core/external.cmake
@@ -13,9 +13,19 @@ if (MALLOY_DEPENDENCY_FMT_DOWNLOAD)
     FetchContent_Declare( 
         fmt 
         GIT_REPOSITORY https://github.com/fmtlib/fmt
-        GIT_TAG v7.1.3 # Highest supported by spdlog 1.8.3 
+        GIT_TAG 7.1.3 # Highest supported by spdlog 1.8.3 
     )
-    FetchContent_MakeAvailable(fmt)
+    FetchContent_GetProperties(fmt)
+    if (NOT fmt_POPULATED) 
+        FetchContent_Populate(fmt)
+        set(MALLOY_TMP_VAR1 ${BUILD_SHARED_LIBS})
+        set(BUILD_SHARED_LIBS ${MALLOY_BUILD_SHARED}) # fmt has no specific shared option
+
+        add_subdirectory(${fmt_SOURCE_DIR} ${fmt_BINARY_DIR})
+
+        set(BUILD_SHARED_LIBS ${MALLOY_TMP_VAR1})
+
+    endif()
 
 else() 
     find_package(fmt REQUIRED)

--- a/lib/malloy/core/external.cmake
+++ b/lib/malloy/core/external.cmake
@@ -9,6 +9,18 @@ find_package(
     REQUIRED
 )
 
+if (MALLOY_DEPENDENCY_FMT_DOWNLOAD) 
+    FetchContent_Declare( 
+        fmt 
+        GIT_REPOSITORY https://github.com/fmtlib/fmt
+        GIT_TAG v7.1.3 # Highest supported by spdlog 1.8.3 
+    )
+    FetchContent_MakeAvailable(fmt)
+
+else() 
+    find_package(fmt REQUIRED)
+endif()
+
 ########################################################################################################################
 # spdlog
 ########################################################################################################################
@@ -22,12 +34,14 @@ if (MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD)
     if (NOT spdlog_POPULATED) 
         FetchContent_Populate(spdlog)
         set(SPDLOG_BUILD_SHARED ${MALLOY_BUILD_SHARED} CACHE INTERNAL "")
+        set(SPDLOG_FMT_EXTERNAL ON CACHE INTERNAL "")
 
         add_subdirectory(${spdlog_SOURCE_DIR} ${spdlog_BINARY_DIR})
     endif()
 else()
     find_package(spdlog REQUIRED)
 endif()
+
 
 ########################################################################################################################
 # OpenSSL

--- a/lib/malloy/core/external.cmake
+++ b/lib/malloy/core/external.cmake
@@ -13,7 +13,7 @@ if (MALLOY_DEPENDENCY_FMT_DOWNLOAD)
     FetchContent_Declare( 
         fmt 
         GIT_REPOSITORY https://github.com/fmtlib/fmt
-        GIT_TAG 7.1.3 # Highest supported by spdlog 1.8.3 
+        GIT_TAG 8.0.1 # Supported by spdlog 1.9.0
     )
     FetchContent_GetProperties(fmt)
     if (NOT fmt_POPULATED) 
@@ -38,7 +38,7 @@ if (MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD)
     FetchContent_Declare(
         spdlog
         GIT_REPOSITORY https://github.com/gabime/spdlog
-        GIT_TAG        v1.8.3
+        GIT_TAG        v1.9.0
     )
     FetchContent_GetProperties(spdlog)
     if (NOT spdlog_POPULATED) 

--- a/lib/malloy/core/websocket/connection.hpp
+++ b/lib/malloy/core/websocket/connection.hpp
@@ -9,7 +9,7 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/beast/core/error.hpp>
-#include <spdlog/fmt/fmt.h>
+#include <fmt/format.h>
 #include <spdlog/spdlog.h>
 
 #include <concepts>

--- a/lib/malloy/target_setup.cmake
+++ b/lib/malloy/target_setup.cmake
@@ -36,6 +36,7 @@ function(malloy_target_common_setup TARGET)
         ${TARGET}
         PUBLIC
             BOOST_BEAST_USE_STD_STRING_VIEW
+            SPDLOG_FMT_EXTERNAL
             $<$<BOOL:${MALLOY_FEATURE_TLS}>:MALLOY_FEATURE_TLS>
             $<$<BOOL:${WIN32}>:UNICODE>
             $<$<BOOL:${WIN32}>:_UNICODE>
@@ -61,6 +62,7 @@ function(malloy_target_common_setup TARGET)
         PUBLIC
             spdlog::spdlog
             Boost::headers
+            fmt::fmt
             $<$<BOOL:${MALLOY_FEATURE_TLS}>:OpenSSL::Crypto>
             $<$<BOOL:${MALLOY_FEATURE_TLS}>:OpenSSL::SSL>
             $<$<AND:$<BOOL:${MALLOY_FEATURE_TLS}>,$<BOOL:${WIN32}>>:crypt32>        # ToDo: This is only needed when MALLOY_FEATURE_CLIENT is ON

--- a/lib/malloy/target_setup.cmake
+++ b/lib/malloy/target_setup.cmake
@@ -37,6 +37,7 @@ function(malloy_target_common_setup TARGET)
         PUBLIC
             BOOST_BEAST_USE_STD_STRING_VIEW
             SPDLOG_FMT_EXTERNAL
+            $<$<BOOL:${MALLOY_BUILD_SHARED}>:FMT_SHARED>
             $<$<BOOL:${MALLOY_FEATURE_TLS}>:MALLOY_FEATURE_TLS>
             $<$<BOOL:${WIN32}>:UNICODE>
             $<$<BOOL:${WIN32}>:_UNICODE>

--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ Building (and using) this library requires:
 Required:
 - [Boost](https://www.boost.org/) 1.74.0 or newer
 - [spdlog](https://github.com/gabime/spdlog) 1.8.3 or newer
+- [fmt](https://github.com/fmtlib/fmt) 7.1.3 or newer (must be compatible with spdlog version)
 
 Optional:
 - OpenSSL
@@ -222,3 +223,4 @@ Various `cmake` options are available to control the build:
 | `MALLOY_FEATURE_HTML` | `ON` | Whether to enable HTML support. |
 | `MALLOY_FEATURE_TLS` | `OFF` | Whether to enable TLS support. |
 | `MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD` | `ON` | Whether to use `FetchContent()` to pull in `spdlog`. If set to `OFF`, `find_package()` is used instead. |
+| `MALLOY_DEPENDENCY_FMT_DOWNLOAD` | `ON` | Same as above but for `fmt` |


### PR DESCRIPTION
This adds fmt as a full dependency alongside spdlog. 

**Changes**

- `fmt` is now looked for and linked to independent from `spdlog`, and has a download automatically option 
- `spdlog` is now told to use external `fmt` (and this is propagated to consumers of `malloy-*`) 
- All includes of `spdlog`'s bundled fmt have been replaced by includes of the standalone fmt 

**Notes**

fmt exposes different symbols (or I'm guessing thats the issue anyway) depending on the value of `FMT_SHARED` at build time. The fedora package for fmt is missing these symbols (despite the fact its a shared lib) and fails to link when building malloy as a shared lib. I've confirmed it works with the downloaded fmt and an fmt I built from source with the proper flags. 

---

Resolves #78 