### PR TITLE
Add access policy support

### DIFF
--- a/examples/server/CMakeLists.txt
+++ b/examples/server/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(routing)
 add_subdirectory(session)
 add_subdirectory(websocket)
 add_subdirectory(custom-request-filter)
+add_subdirectory(http_auth)
 
 if (MALLOY_FEATURE_TLS)
     add_subdirectory(ssl)

--- a/examples/server/http_auth/CMakeLists.txt
+++ b/examples/server/http_auth/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Set a target name
+set(TARGET malloy-example-server-http-auth)
+
+# Create the executable
+add_executable(${TARGET})
+
+# Setup example
+include(../example.cmake)
+malloy_example_setup(${TARGET})
+
+# Add source files
+target_sources(
+    ${TARGET}
+    PRIVATE
+        main.cpp
+)

--- a/examples/server/http_auth/main.cpp
+++ b/examples/server/http_auth/main.cpp
@@ -1,0 +1,95 @@
+#include "../../example.hpp"
+
+#include <malloy/core/http/generator.hpp>
+#include <malloy/server/controller.hpp>
+#include <malloy/server/routing/router.hpp>
+#include <malloy/server/auth/basic.hpp>
+
+#include <iostream>
+#include <memory>
+
+
+// Borrowed from: https://stackoverflow.com/a/5291537/12448530
+struct b64_decode {
+
+    template<malloy::concepts::dynamic_buffer Buff>
+    static void decode(std::string_view in, Buff& out_raw) {
+        constexpr char reverse_table[128] = {
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
+            64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
+            52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64,
+            64,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
+            15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 64, 64, 64, 64, 64,
+            64, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
+            41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 64, 64, 64, 64, 64
+        };
+        const auto needed = static_cast<std::size_t>(std::ceil(4 * (static_cast<double>(in.size()) / 3.0)));
+        auto out = out_raw.prepare(needed);
+        const auto last = in.end();
+        int bits_collected = 0;
+        unsigned int accumulator = 0;
+        auto out_iter = reinterpret_cast<unsigned char*>(out.data());
+
+        for (auto i = in.begin(); i != last; ++i) {
+            const int c = *i;
+            if (std::isspace(c) || c == '=') {
+                // Skip whitespace and padding. Be liberal in what you accept.
+                continue;
+            }
+            if ((c > 127) || (c < 0) || (reverse_table[c] > 63)) {
+                throw std::invalid_argument("This contains characters not legal in a base64 encoded string.");
+            }
+            accumulator = (accumulator << 6) | reverse_table[c];
+            bits_collected += 6;
+            if (bits_collected >= 8) {
+                bits_collected -= 8;
+                *out_iter = static_cast<char>((accumulator >> bits_collected) & 0xffu);
+                ++out_iter;
+            }
+        }
+    }
+
+};
+
+int main()
+{
+    // Create malloy controller config
+    malloy::server::controller::config cfg;
+    cfg.interface   = "127.0.0.1";
+    cfg.port        = 8080;
+    cfg.doc_root    = examples_doc_root;
+    cfg.num_threads = 5;
+    cfg.logger      = create_example_logger();
+
+    // Create malloy controller
+    malloy::server::controller c;
+    if (!c.init(cfg)) {
+        std::cerr << "could not start controller." << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    // Create the router
+    auto router = c.router();
+    using namespace malloy::http;
+
+    // A simple GET route handler
+    router->add_policy("/", malloy::server::http::auth::basic<b64_decode>{"username", "password", "My Realm"});
+    router->add(method::get, "/", [](const auto& req) {
+      response res{status::ok};
+      res.body() = "<html><body><h1>Hello World!</h1><p>some content...</p></body></html>";
+      return res;
+    });
+
+
+    // Start
+    c.start();
+
+    // Keep the application alive
+    while (true)
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    return EXIT_SUCCESS;
+}
+
+

--- a/lib/malloy/server/CMakeLists.txt
+++ b/lib/malloy/server/CMakeLists.txt
@@ -15,6 +15,7 @@ malloy_target_common_setup(${TARGET})
 add_subdirectory(http)
 add_subdirectory(routing)
 add_subdirectory(websocket)
+add_subdirectory(auth)
 
 # Add sources
 target_sources(

--- a/lib/malloy/server/auth/CMakeLists.txt
+++ b/lib/malloy/server/auth/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(
+        ${TARGET}
+        PUBLIC
+            basic.hpp
+)
+

--- a/lib/malloy/server/auth/basic.hpp
+++ b/lib/malloy/server/auth/basic.hpp
@@ -1,0 +1,110 @@
+#pragma once
+
+#include "malloy/core/http/type_traits.hpp"
+#include "malloy/core/http/response.hpp"
+#include "malloy/core/http/generator.hpp"
+
+#include <fmt/format.h>
+
+namespace malloy::server::http::auth
+{
+    namespace detail {
+        struct auth_field {
+            std::string method;
+            std::string username;
+            std::string password;
+        };
+
+        template<typename D>
+        struct base64_decoder_helper {
+            void operator()(std::string_view v, std::string s) {
+                auto b = boost::asio::dynamic_buffer(s);
+                D::decode(v, s);
+            }
+        };
+        template<typename D>
+        concept base64_decoder = requires(std::string_view v, std::string s) {
+            { base64_decoder_helper<D>{}(v, s) };
+        };
+        template<base64_decoder Decoder>
+        inline auto parse_auth_field(std::string_view txt) -> std::optional<auth_field> {
+            auto method_pos = txt.find_first_of(' ');
+            if (method_pos == std::string::npos) {
+                return std::nullopt;
+            }
+
+            auto encoded_usepass = std::string_view{txt.begin() + method_pos + 1, txt.end()};
+            try {
+                std::string out;
+                auto outbuff = boost::asio::dynamic_buffer(out);
+                Decoder::decode(encoded_usepass, outbuff);
+                out.erase(std::find(out.begin(), out.end(), '\0'), out.end());
+                const auto parsed_usepass = malloy::split(out, ":");
+                if (parsed_usepass.size() != 2) {
+                    return std::nullopt;
+                }
+
+                return auth_field{std::string{txt.begin(), txt.begin() + method_pos}, std::string{parsed_usepass.at(0)}, std::string{parsed_usepass.at(1)}};
+            } catch (const std::invalid_argument&) {
+                return std::nullopt;
+            }
+        }
+    }
+    template<detail::base64_decoder Decoder, malloy::http::concepts::body BodyType = boost::beast::http::string_body>
+    class basic {
+        static constexpr auto cli_auth_field_name = "Authorization";
+    public:
+        using body_type = BodyType;
+        using response_type = malloy::http::response<body_type>;
+
+        basic(std::string username, std::string password, std::string realm) : m_username{std::move(username)}, m_password{std::move(password)}, m_realm{std::move(realm)} {
+            rebuild_www_auth_txt();
+        }
+
+        void set_charset(const std::string& chset) {
+            m_charset = chset;
+            rebuild_www_auth_txt();
+        }
+
+        auto operator()(const boost::beast::http::request_header<>& h) -> std::optional<response_type> {
+
+            auto auth_iter = h.find(cli_auth_field_name);
+            if (auth_iter == h.end()) {
+                // No auth header
+                return not_authed_resp();
+            }
+            auto maybe_parsed = detail::parse_auth_field<Decoder>(auth_iter->value());
+            if (!maybe_parsed) {
+                return not_authed_resp();
+            }
+
+            const auto auth_details = std::move(*maybe_parsed);
+            const auto r1 = auth_details.method != "Basic";
+            const auto r2 = auth_details.username != m_username;
+            const auto r3 = auth_details.password != m_password;
+            if ((auth_details.method != std::string_view{"Basic"}) || (auth_details.username != m_username) || (auth_details.password != m_password)) {
+                return not_authed_resp();
+            } else {
+                return std::nullopt;
+            }
+        }
+    private:
+        void rebuild_www_auth_txt() {
+            m_www_auth = fmt::format(R"(Basic realm="{}", charset="{}")", m_realm, m_charset);
+        }
+
+        auto not_authed_resp() -> response_type {
+            response_type resp{malloy::http::status::unauthorized};
+            resp.set(boost::beast::http::field::www_authenticate, m_www_auth);
+            resp.prepare_payload();
+            return resp;
+        }
+
+        std::string m_username;
+        std::string m_password;
+        std::string m_realm;
+        std::string m_www_auth;
+        std::string m_charset{"UTF-8"};
+    };
+}
+

--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -98,6 +98,57 @@ namespace malloy::server
      */
     class router
     {
+        class abstract_req_validator {
+        public:
+            virtual ~abstract_req_validator() = default;
+            virtual auto process(const boost::beast::http::request_header<>&, const http::connection_t& conn) -> bool = 0;
+        };
+        template<concepts::request_validator V, typename Writer>
+        class req_validator_impl: public abstract_req_validator {
+        public:
+            Writer writer;
+
+            req_validator_impl(V validator, Writer writer_) : writer{std::move(writer_)}, validator_{std::move(validator)} {}
+
+            auto process(const boost::beast::http::request_header<>& h, const http::connection_t& conn) -> bool override {
+                auto maybe_resp = std::invoke(validator_, h);
+                if (!maybe_resp) {
+                    return false;
+                } else {
+                    writer(h, std::move(*maybe_resp), conn);
+                }
+            }
+
+        private:
+            V validator_;
+        };
+        class policy_store {
+        public:
+            policy_store(std::string reg, std::unique_ptr<abstract_req_validator> validator) : m_validator{std::move(validator)}, m_raw_reg{std::move(reg)} {}
+
+            auto process(const boost::beast::http::request_header<>& h, const http::connection_t& conn) -> bool {
+                if (!matches(h.target())) {
+                    return false;
+                } else {
+                    return m_validator->process(h, conn);
+                }
+            }
+        private:
+            auto matches(std::string_view url) -> bool {
+                if (!m_compiled_reg) {
+                    compile_match_expr();
+                }
+                std::string surl{url.begin(), url.end()}; // Must be null terminated
+                return std::regex_match(surl, *m_compiled_reg);
+            }
+            void compile_match_expr() {
+                m_compiled_reg = std::regex{m_raw_reg};
+            }
+            std::unique_ptr<abstract_req_validator> m_validator;
+            std::optional<std::regex> m_compiled_reg;
+            std::string m_raw_reg;
+            
+        };
     public:
         template<typename Derived>
         using req_generator = std::shared_ptr<typename http::connection<Derived>::request_generator>;
@@ -251,6 +302,14 @@ namespace malloy::server
          */
         bool add_websocket(std::string&& resource, typename websocket::connection::handler_t&& handler);
 
+        template<concepts::request_validator Policy>
+        void add_policy(const std::string& target, Policy&& policy) {
+            using policy_t = std::decay_t<Policy>;
+            auto writer = [this](const auto& header, auto&& resp, auto&& conn) { detail::send_response(header, std::forward<decltype(resp)>(resp), std::move(conn), m_server_str); };
+
+            m_policies.emplace_back(target, std::make_unique<req_validator_impl<policy_t, decltype(writer)>>(std::forward<Policy>(policy), std::move(writer)));
+        }
+
         /**
          * Handle a request.
          *
@@ -387,6 +446,7 @@ namespace malloy::server
         std::unordered_map<std::string, std::shared_ptr<router>> m_sub_routers;
         std::vector<std::shared_ptr<endpoint_http>> m_endpoints_http;
         std::vector<std::shared_ptr<endpoint_websocket>> m_endpoints_websocket;
+        std::vector<policy_store> m_policies;
         std::string m_server_str{BOOST_BEAST_VERSION_STRING};
 
         /// Create the lambda wrapped callback for the writer

--- a/lib/malloy/server/routing/type_traits.hpp
+++ b/lib/malloy/server/routing/type_traits.hpp
@@ -34,6 +34,11 @@ namespace malloy::server::concepts
     // clang-format on
     };
 
+    template<typename P>
+    concept request_validator = requires(P p, const boost::beast::http::request_header<>& h) {
+        { std::invoke(p, h) } -> malloy::concepts::is_container_of<malloy::http::response, std::optional>;
+    };
+
 } // namespace malloy::server::concepts
 
 /**

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -10,3 +10,47 @@
  * which means that we have to include them again as we generate multiple translation units.
  */
 #include <iostream>
+#include <functional>
+#include <malloy/client/controller.hpp>
+#include <malloy/server/controller.hpp>
+
+namespace malloy::test
+{
+    /**
+     * Performs a roundtrip using server & client components.
+     *
+     * @param port The port to perform the test on.
+     * @param setup_client The client setup routine.
+     * @param setup_server The server setup routine.
+     */
+    inline void roundtrip(
+        const uint16_t port,
+        std::function<void(malloy::client::controller&)> setup_client,
+        std::function<void(malloy::server::controller&)> setup_server)
+    {
+        namespace mc = malloy::client;
+        namespace ms = malloy::server;
+        mc::controller c_ctrl;
+        ms::controller s_ctrl;
+
+        malloy::controller::config general_cfg;
+        general_cfg.num_threads = 2;
+        general_cfg.logger = spdlog::default_logger();
+
+        ms::controller::config server_cfg{general_cfg};
+        server_cfg.interface = "127.0.0.1";
+        server_cfg.port = port;
+
+        mc::controller::config cli_cfg{general_cfg};
+
+        REQUIRE(s_ctrl.init(server_cfg));
+        REQUIRE(c_ctrl.init(cli_cfg));
+
+        setup_server(s_ctrl);
+        setup_client(c_ctrl);
+
+        REQUIRE(s_ctrl.start());
+        CHECK(c_ctrl.run());
+        c_ctrl.stop().get();
+    }
+}

--- a/test/test_suites/components/router.cpp
+++ b/test/test_suites/components/router.cpp
@@ -8,13 +8,6 @@ using namespace malloy::server;
 TEST_SUITE("components - router")
 {
     TEST_CASE("policies block unaccepted requests") {
-        struct always_blocked {
-            template<typename T>
-            auto operator()(T) -> std::optional<response<>> {
-                response<> res{status::unauthorized};
-                return res;
-            }
-        };
         constexpr auto port = 4413;
         malloy::test::roundtrip(port, [&, port](auto& c_ctrl){
                 request<> req{method::get, "127.0.0.1", port, "/"};
@@ -27,7 +20,7 @@ TEST_SUITE("components - router")
                 r->add(method::get, "/", [](const auto& req){
                     return generator::ok();
                 });
-                r->add_policy("/", always_blocked{});
+                r->add_policy("/", [](auto) -> std::optional<response<>> { return response<>{status::unauthorized}; });
             });
     }
 

--- a/test/test_suites/components/router.cpp
+++ b/test/test_suites/components/router.cpp
@@ -9,7 +9,8 @@ TEST_SUITE("components - router")
 {
     TEST_CASE("policies block unaccepted requests") {
         struct always_blocked {
-            auto operator()(auto) -> std::optional<response<>> {
+            template<typename T>
+            auto operator()(T) -> std::optional<response<>> {
                 response<> res{status::unauthorized};
                 return res;
             }


### PR DESCRIPTION
This adds support for access policies as a customisation point. The usage is similar to preflights and currently the only requirement is that its invocable with a `const boost::beast::http::request_header&` and returns `std::optional<malloy::http::response<...>>`. The body type for the response can be anything. 

I've also added a basic http authentication policy, which uses template-based dependency injection for the base64 decoding. I think the implementation is correct but I didn't actually know how http authentication worked at the protocol level until I started writing it, so I'm not 100% on it (seems to work when testing with a browser though).

One important note is that policies are only checked for http requests (not websocket) and only once a handler is actually found for it. i.e. if no handler is avaliable for the specified route, no policies will be used even if they match. 

Implements: #76 