### PR TITLE
Fix spdlog 1.9.1 compile

### DIFF
--- a/lib/malloy/core/detail/version_checks.hpp
+++ b/lib/malloy/core/detail/version_checks.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <fmt/format.h>
+
+#if (FMT_VERSION >= (8 * 10000)) // fmt version is major * 10,000 ...
+    #define MALLOY_DETAIL_HAS_FMT_8 1
+#else
+    #define MALLOY_DETAIL_HAS_FMT_8 0
+#endif

--- a/lib/malloy/core/external.cmake
+++ b/lib/malloy/core/external.cmake
@@ -41,7 +41,7 @@ if (MALLOY_DEPENDENCY_SPDLOG_DOWNLOAD)
     FetchContent_Declare(
         spdlog
         GIT_REPOSITORY https://github.com/gabime/spdlog
-        GIT_TAG        v1.9.0
+        GIT_TAG        v1.9.2
     )
     FetchContent_GetProperties(spdlog)
     if (NOT spdlog_POPULATED) 

--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -555,7 +555,7 @@ namespace malloy::server
         bool log_or_throw(const std::exception& exception, const spdlog::level::level_enum level, const FormatString& fmt, Args&&... args)
         {
             if (m_logger) {
-                m_logger->log(level, fmt, std::forward<Args>(args)...);
+                m_logger->log(level, fmt::runtime(fmt), std::forward<Args>(args)...);
                 return false;
             }
 

--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -17,6 +17,7 @@
 #if MALLOY_FEATURE_TLS
     #include "../http/connection_tls.hpp"
 #endif
+#include "malloy/core/detail/version_checks.hpp"
 
 #include <boost/beast/core.hpp>
 #include <boost/beast/http.hpp>
@@ -555,7 +556,14 @@ namespace malloy::server
         bool log_or_throw(const std::exception& exception, const spdlog::level::level_enum level, const FormatString& fmt, Args&&... args)
         {
             if (m_logger) {
-                m_logger->log(level, fmt::runtime(fmt), std::forward<Args>(args)...);
+                m_logger->log(level,
+#if MALLOY_DETAIL_HAS_FMT_8
+                              fmt::runtime(fmt)
+#else
+                              fmt
+#endif
+                                  ,
+                              std::forward<Args>(args)...);
                 return false;
             }
 


### PR DESCRIPTION
This fixes the issues I was encountering with spdlog > 1.9.0. Further documented in #85. 

It does **not** fix the main issue of #85, as far as I know anyway. 

This also bumps the spdlog version pulled in to be 1.9.2, which provides better support for fmt 8 such as compile-time checked format strings (which was why it didn't compile originally). A macro is used to allow compatibility with versions of fmt < 8, which I think is wanted?