### PR TITLE
Fix action queue

### DIFF
--- a/lib/malloy/core/detail/action_queue.hpp
+++ b/lib/malloy/core/detail/action_queue.hpp
@@ -70,7 +70,7 @@ namespace malloy::detail
                     auto act = std::move(m_acts.front());
                     m_acts.pop();
                     std::invoke(std::move(act), [this] {
-                        if (!m_acts.empty()) { exe_next(); }
+                        if (!m_acts.empty()) { exe_next(); } else { currently_running_act_ = false; }
                     });
                 } else {
                     currently_running_act_ = false;

--- a/lib/malloy/core/detail/action_queue.hpp
+++ b/lib/malloy/core/detail/action_queue.hpp
@@ -1,13 +1,14 @@
-#pragma once 
+#pragma once
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/strand.hpp>
 
 #include <queue>
 
-namespace malloy::detail {
+namespace malloy::detail
+{
 
-/**
+    /**
  * @class action_queue
  * @brief Stores and executes functions
  * @details The next queued function is not executed until the callback passed to the last executed function is called
@@ -17,68 +18,70 @@ namespace malloy::detail {
  * @warning Objects of this class do no explicit lifetime management for themselves. It is up to the owner of the object to ensure it is still alive when the callback is invoked
  * @tparam Executor The executor to use
  */
-template<typename Executor>
-class action_queue {
-    using act_t = std::function<void(const std::function<void()>&)>;
-    using acts_t = std::queue<act_t>;
-    using ioc_t = boost::asio::strand<Executor>;
+    template<typename Executor>
+    class action_queue
+    {
+        using act_t = std::function<void(const std::function<void()>&)>;
+        using acts_t = std::queue<act_t>;
+        using ioc_t = boost::asio::strand<Executor>;
 
-    struct inner_data : public std::enable_shared_from_this<inner_data> {
+        struct inner_data : public std::enable_shared_from_this<inner_data> {
+        };
 
-
-    };
-public:
-    /**
+    public:
+        /**
      * @brief Construct the action queue. It will not execute anything until run() is called
      * @param ioc The strand to use for synchronisation
      */
-    explicit action_queue(ioc_t ioc) :
-        m_ioc{std::move(ioc)} {}
+        explicit action_queue(ioc_t ioc) :
+            m_ioc{std::move(ioc)} {}
 
-    /**
+        /**
      * @brief Add an action to the queue
      * @note If run() has been called and the queue is currently empty, the new action will run immediately
      * @param act
      */
-    void push(act_t act) {
-        boost::asio::dispatch(m_ioc, [this, act = std::move(act)]() mutable -> void {
-            m_acts.push(std::move(act));
-            if (m_acts.size() == 1 && m_running) {
-                run();
-            }
-        });
-    }
-    /**
+        void push(act_t act)
+        {
+            boost::asio::dispatch(m_ioc, [this, act = std::move(act)]() mutable -> void {
+                m_acts.push(std::move(act));
+                if (!currently_running_act_) {
+                    run();
+                }
+            });
+        }
+        /**
      * @brief Starts the queue running, if it isn't already
      * @note Only needs to be called once
      */
-    void run() {
-        m_running = true;
-        exe_next();
-    }
+        void run()
+        {
+            m_running = true;
+            exe_next();
+        }
 
 
-private:
-    void exe_next()
-    {
-        boost::asio::dispatch(m_ioc, [this] {
-            if (!m_acts.empty()) {
-                auto act = std::move(m_acts.front());
-                m_acts.pop();
-                std::invoke(std::move(act), [this] {
-                    if (!m_acts.empty()) { exe_next(); }
-                });
-            }
-        });
-    }
+    private:
+        void exe_next()
+        {
+            currently_running_act_ = true;
+            boost::asio::dispatch(m_ioc, [this] {
+                if (!m_acts.empty()) {
+                    auto act = std::move(m_acts.front());
+                    m_acts.pop();
+                    std::invoke(std::move(act), [this] {
+                        if (!m_acts.empty()) { exe_next(); }
+                    });
+                } else {
+                    currently_running_act_ = false;
+                }
+            });
+        }
 
-    acts_t m_acts;
-    ioc_t m_ioc;
-    std::atomic_bool m_running{false};
+        acts_t m_acts;
+        ioc_t m_ioc;
+        std::atomic_bool m_running{false};
+        std::atomic_bool currently_running_act_{false};
+    };
 
-};
-
-}
-
-
-
+}    // namespace malloy::detail


### PR DESCRIPTION
This fixes a bug introduced in #82 (oops). Basically if an `action_queue` was currently empty, any pushed actions would execute unqueued. I haven't got a unit test for it because I'm not sure how to test it, if anyone has any ideas I'm all ears.

fixes: #87 
