### PR TITLE
[draft] add support for asio CompletionToken api for client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,18 @@ option(MALLOY_DEPENDENCY_FMT_DOWNLOAD "Whether to automatically fetch fmt" ON)
 option(MALLOY_DEPENDENCY_JSON_DOWNLOAD "Whether to automatically fetch nlohmann/json" ON)
 option(MALLOY_DEPENDENCY_INJA_DOWNLOAD "Whether to automatically fetch pantor/inja" ON)
 
+if (MALLOY_BUILD_TESTS)
+    option(MALLOY_BUILD_CORO_TESTS "Whether to build the coroutine tests, currently disabled by default due to a gcc bug" OFF)
+endif()
+if (MALLOY_BUILD_EXAMPLES)
+    if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+        set(TMP ON)
+    else()
+        set(TMP OFF)
+    endif()
+    option(MALLOY_BUILD_CORO_EXAMPLES "Whether to build the coroutine examples, defaults to off for everything but gcc" ${TMP})
+endif()
+
 # Settings
 set(MALLOY_WIN32_WINNT "0x0A00")
 

--- a/examples/client/CMakeLists.txt
+++ b/examples/client/CMakeLists.txt
@@ -7,4 +7,7 @@ if (MALLOY_FEATURE_TLS)
     add_subdirectory(http_tls)
     add_subdirectory(websocket_secure)
 endif()
+if (MALLOY_BUILD_CORO_EXAMPLES)
+    add_subdirectory(http-plain-coro)
+endif()
 

--- a/examples/client/http-plain-coro/CMakeLists.txt
+++ b/examples/client/http-plain-coro/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Set a target name
+set(TARGET malloy-example-client-http-plain-coro)
+
+# Create the executable
+add_executable(${TARGET})
+
+# Setup example
+include(../example.cmake)
+malloy_example_setup_client(${TARGET})
+
+# Add source files
+target_sources(
+    ${TARGET}
+    PRIVATE
+        main.cpp
+)

--- a/examples/client/http_tls/main.cpp
+++ b/examples/client/http_tls/main.cpp
@@ -1,5 +1,6 @@
 #include "../../example.hpp"
 
+#include <boost/asio/use_future.hpp>
 #include <malloy/client/controller.hpp>
 
 #include <iostream>
@@ -34,12 +35,13 @@ int main()
         443,
         "/"
     );
-    auto stop_token = c.https_request(req, [](auto&& resp) mutable {
-        std::cout << resp << std::endl;
-    });
-    const auto ec = stop_token.get();
-    if (ec) {
-        spdlog::error(ec.message());
+
+    auto stop_token = c.https_request(req, boost::asio::use_future);
+    try {
+        std::cout << stop_token.get() << "\n";
+
+    } catch(const std::future_error& e) {
+        spdlog::error(e.what());
         return EXIT_FAILURE;
     }
 

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -121,7 +121,7 @@ namespace malloy::client
          * @sa http_request()
          */
         template<malloy::http::concepts::body ReqBody, typename Callback, concepts::response_filter Filter = detail::default_resp_filter>
-        requires concepts::http_callback<Callback, Filter>
+        requires concepts::http_completion_token<Callback, tmp::bodies_for_t<std::remove_cvref_t<Filter>>>
         auto https_request(malloy::http::request<ReqBody> req, Callback&& done, Filter filter = {})
         {
             return make_http_connection<true>(std::move(req), std::forward<Callback>(done), std::move(filter));

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -226,13 +226,13 @@ namespace malloy::client
                     std::make_shared<http::connection_tls<Body, Filter, std::remove_cvref_t<decltype(act)>>>(
                         m_cfg.logger->clone(m_cfg.logger->name() + " | HTTP connection"),
                         io_ctx(),
-                        *m_tls_ctx, std::forward<decltype(act)>(act), std::forward<decltype(args)>(args)...);
+                        *m_tls_ctx, std::forward<decltype(act)>(act), std::forward<decltype(args)>(args)...)->start();
                     return;
                 }
 #endif
                 std::make_shared<http::connection_plain<Body, Filter, std::remove_cvref_t<decltype(act)>>>(
                     m_cfg.logger->clone(m_cfg.logger->name() + " | HTTP connection"),
-                    io_ctx(), std::forward<decltype(act)>(act), std::forward<decltype(args)>(args)...);
+                    io_ctx(), std::forward<decltype(act)>(act), std::forward<decltype(args)>(args)...)->start();
             };
             if (!malloy::http::has_field(req, malloy::http::field::user_agent)) {
                     req.set(malloy::http::field::user_agent, m_cfg.user_agent);

--- a/lib/malloy/client/controller.hpp
+++ b/lib/malloy/client/controller.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "http/connection_plain.hpp"
-#include "malloy/core/then.hpp"
 #include "type_traits.hpp"
 #include "websocket/connection.hpp"
 #include "../core/controller.hpp"
@@ -287,14 +286,13 @@ namespace malloy::client
                             std::invoke(act, ec, conn);
                             }
                         });
-                    }};
+                    } };
 
             auto resolve_wrapper = [host, port, resolver, on_resolve = std::move(on_resolve)](auto done) mutable {
-                    resolver->async_resolve(
+                resolver->async_resolve(
                     host,
                     std::to_string(port),
-                    [done = std::forward<decltype(done)>(done), on_resolve = std::move(on_resolve)](auto ec, auto rs) mutable { on_resolve(std::forward<decltype(done)>(done), ec, rs); }
-                );
+                    [done = std::forward<decltype(done)>(done), on_resolve = std::move(on_resolve)](auto ec, auto rs) mutable { on_resolve(std::forward<decltype(done)>(done), ec, rs); });
             };
             return boost::asio::async_initiate<decltype(handler), void(error_code, std::shared_ptr<websocket::connection>)>(std::move(resolve_wrapper), handler);
         }

--- a/lib/malloy/client/http/connection.hpp
+++ b/lib/malloy/client/http/connection.hpp
@@ -200,7 +200,7 @@ namespace malloy::client::http
         }
         void report_err(error_code ec) {
             tmp::filter_resp_t<Filter> v;
-            (*m_cb)(ec, v);
+            (*m_cb)(ec, std::move(v));
         }
     };
 

--- a/lib/malloy/client/http/connection_plain.hpp
+++ b/lib/malloy/client/http/connection_plain.hpp
@@ -16,8 +16,9 @@ namespace malloy::client::http
     {
         using parent_t = connection<connection_plain<ConnArgs...>, ConnArgs...>;
     public:
-        connection_plain(std::shared_ptr<spdlog::logger> logger, boost::asio::io_context& io_ctx) :
-            parent_t(std::move(logger), io_ctx),
+        template<typename... Args>
+        connection_plain(std::shared_ptr<spdlog::logger> logger, boost::asio::io_context& io_ctx, Args&&... args) :
+            parent_t(std::move(logger), io_ctx, std::forward<Args>(args)...),
             m_stream(boost::asio::make_strand(io_ctx))
         {
         }

--- a/lib/malloy/client/http/connection_tls.hpp
+++ b/lib/malloy/client/http/connection_tls.hpp
@@ -18,12 +18,13 @@ namespace malloy::client::http
     {
         using parent_t = connection<connection_tls<ConnArgs...>, ConnArgs...>;
     public:
+        template<typename... Args>
         connection_tls(
             std::shared_ptr<spdlog::logger> logger,
             boost::asio::io_context& io_ctx,
-            boost::asio::ssl::context& tls_ctx
+            boost::asio::ssl::context& tls_ctx, Args&&... args
         ) :
-            parent_t(std::move(logger), io_ctx),
+            parent_t(std::move(logger), io_ctx, std::forward<Args>(args)...),
             m_stream(boost::asio::make_strand(io_ctx), tls_ctx)
         {
         }

--- a/lib/malloy/client/tmp.hpp
+++ b/lib/malloy/client/tmp.hpp
@@ -7,6 +7,7 @@
 namespace malloy::client::tmp {
 
 namespace detail {
+/// Helper to map variant<T...> to variant<response<T>...>
 template<template<typename...> typename V, typename... Vargs>
 struct conv_to_resp_helper {
     constexpr conv_to_resp_helper(V<Vargs...>) {}
@@ -14,17 +15,23 @@ struct conv_to_resp_helper {
 };
 }
 
+/**
+ * @brief Converts from a variant of possible bodies to the actual body type taken by callbacks
+ */
 template<typename V>
 requires (malloy::concepts::is_variant_of_bodies<V>)
 using body_type = malloy::tmp::unwrap_variant<V>;
 
+/// Resolves the body type used by a filter F
 template<typename F>
 using bodies_for_t = std::invoke_result_t<decltype(&F::body_for), const F*, const typename F::header_type&>;
 
+/// Converts a variant<T...> where T is body to a variant<response<T>...>
 template<typename Bodies>
 requires (malloy::concepts::is_variant_of_bodies<Bodies>)
 using to_responses = typename decltype(detail::conv_to_resp_helper{std::declval<Bodies>()})::type;
 
+/// Resolves to the type that must be taken in callbacks handling responses for Filter
 template<typename Filter>
 using filter_resp_t = malloy::tmp::unwrap_variant<to_responses<bodies_for_t<Filter>>>;
 

--- a/lib/malloy/client/tmp.hpp
+++ b/lib/malloy/client/tmp.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "malloy/core/tmp.hpp"
+#include "malloy/core/http/response.hpp"
+#include "malloy/core/type_traits.hpp"
+
+namespace malloy::client::tmp {
+
+namespace detail {
+template<template<typename...> typename V, typename... Vargs>
+struct conv_to_resp_helper {
+    constexpr conv_to_resp_helper(V<Vargs...>) {}
+    using type = V<http::response<Vargs>...>;
+};
+}
+
+template<typename V>
+requires (malloy::concepts::is_variant_of_bodies<V>)
+using body_type = malloy::tmp::unwrap_variant<V>;
+
+template<typename F>
+using bodies_for_t = std::invoke_result_t<decltype(&F::body_for), const F*, const typename F::header_type&>;
+
+template<typename Bodies>
+requires (malloy::concepts::is_variant_of_bodies<Bodies>)
+using to_responses = typename decltype(detail::conv_to_resp_helper{std::declval<Bodies>()})::type;
+
+template<typename Filter>
+using filter_resp_t = malloy::tmp::unwrap_variant<to_responses<bodies_for_t<Filter>>>;
+
+};

--- a/lib/malloy/client/type_traits.hpp
+++ b/lib/malloy/client/type_traits.hpp
@@ -5,39 +5,13 @@
 #include "../core/type_traits.hpp"
 
 #include "malloy/core/tmp.hpp"
+#include "malloy/client/tmp.hpp"
 
 #include <concepts>
 #include <variant>
 
 
-namespace malloy::client {
-namespace tmp {
-
-namespace detail {
-template<template<typename...> typename V, typename... Vargs>
-struct conv_to_resp_helper {
-    constexpr conv_to_resp_helper(V<Vargs...>) {}
-    using type = V<http::response<Vargs>...>;
-};
-}
-
-template<typename V>
-requires (malloy::concepts::is_variant_of_bodies<V>)
-using body_type = malloy::tmp::unwrap_variant<V>;
-
-template<typename F>
-using bodies_for_t = std::invoke_result_t<decltype(&F::body_for), const F*, const typename F::header_type&>;
-
-template<typename Bodies>
-requires (malloy::concepts::is_variant_of_bodies<Bodies>)
-using to_responses = typename decltype(detail::conv_to_resp_helper{std::declval<Bodies>()})::type;
-
-template<typename Filter>
-using filter_resp_t = malloy::tmp::unwrap_variant<to_responses<bodies_for_t<Filter>>>;
-
-};
-
-namespace concepts
+namespace malloy::client::concepts
 {
 
     namespace detail
@@ -97,7 +71,6 @@ namespace concepts
         std::visit(detail::http_cb_helper<F>{std::move(cb)}, f.body_for(h));
     };
 
-}
 }
 
 /** 

--- a/lib/malloy/client/type_traits.hpp
+++ b/lib/malloy/client/type_traits.hpp
@@ -27,30 +27,6 @@ namespace malloy::client::concepts
                 f2.setup_body(h2, r);
             }
         };
-
-
-        /**
-         * @class http_cb_helper
-         * @brief Helper for http_callback concept
-         * @note This is effectively [cb = std::move(cb)]<typename V>(V&& v) mutable { ... }
-         * @tparam Callback carries the functor type being checked by the
-         * concept
-         *
-         */
-        template<typename Callback>
-        struct http_cb_helper {
-            Callback cb;
-
-            template<typename V>
-            void operator()(V&&)
-            {
-                using body_t = std::decay_t<V>;
-                malloy::http::response<body_t> res;
-                error_code ec;
-
-                cb(ec, std::move(res));
-            }
-        };
     }
 
     template<typename T, typename Bodies>
@@ -65,12 +41,6 @@ namespace malloy::client::concepts
         {
             std::visit(detail::response_filter_body_helper<F>{}, f.body_for(h))};
     };
-
-    template<typename F, typename Filter>
-    concept http_callback = response_filter<Filter>&& std::move_constructible<F>&& requires(F cb, const Filter& f, const typename Filter::header_type& h){
-        std::visit(detail::http_cb_helper<F>{std::move(cb)}, f.body_for(h));
-    };
-
 }
 
 /** 

--- a/lib/malloy/core/tmp.hpp
+++ b/lib/malloy/core/tmp.hpp
@@ -5,6 +5,21 @@
 #include <variant>
 
 namespace malloy::tmp {
+
+/**
+ * @brief Pattern:
+ *  unwrap_variant<variant<T>> -> T
+ *  unwrap_variant<variant<T, ...> -> std::variant<T, ...>
+ *
+ *  i.e. If its a 1 element it just returns that type, otherwise the entire variant type
+ */
 template<typename V>
 using unwrap_variant = std::conditional_t<std::variant_size_v<V> == 1, std::variant_alternative_t<0, V>, V>;
 }
+
+/**
+ * @namespace malloy::tmp
+ * @brief Contains template metaprogramming helpers
+ *
+ */
+

--- a/lib/malloy/core/tmp.hpp
+++ b/lib/malloy/core/tmp.hpp
@@ -1,0 +1,10 @@
+
+#pragma once
+
+#include <type_traits>
+#include <variant>
+
+namespace malloy::tmp {
+template<typename V>
+using unwrap_variant = std::conditional_t<std::variant_size_v<V> == 1, std::variant_alternative_t<0, V>, V>;
+}

--- a/lib/malloy/core/type_traits.hpp
+++ b/lib/malloy/core/type_traits.hpp
@@ -3,6 +3,7 @@
 #include "error.hpp"
 
 #include <boost/asio/buffer.hpp>
+#include <boost/asio/connect.hpp>
 #include <boost/beast/core/buffer_traits.hpp>
 
 #include <concepts>
@@ -34,6 +35,10 @@ namespace malloy::concepts
 
     template<typename Func>
     concept accept_handler = std::invocable<Func, malloy::error_code>;
+
+    template<typename Func>
+    concept err_completion_token = boost::asio::completion_token_for<Func, void(malloy::error_code)>;
+
 
     template<typename B>
     concept dynamic_buffer = boost::asio::is_dynamic_buffer<B>::value;

--- a/lib/malloy/core/type_traits.hpp
+++ b/lib/malloy/core/type_traits.hpp
@@ -46,6 +46,10 @@ namespace malloy::concepts
     template<typename Func>
     concept async_read_handler = std::invocable<Func, boost::beast::error_code, std::size_t>;
 
+    template<typename Func>
+    concept read_completion_token = boost::asio::completion_token_for<Func, void(boost::beast::error_code, std::size_t)>;
+
+
     /**
      * Concept to check whether a type has a function with the following signature:
      *   - `std::string operator()()`

--- a/lib/malloy/core/websocket/connection.hpp
+++ b/lib/malloy/core/websocket/connection.hpp
@@ -107,29 +107,28 @@ namespace malloy::websocket
             if (m_state != state::inactive) {
                 throw std::logic_error{"connect() called on already active websocket connection"};
             }
-            boost::asio::async_completion<Callback, void(error_code)> comp{done};
             auto me = this->shared_from_this();
-            auto on_conn = build_then<malloy::error_code>([me](auto after, auto ec){
-                me->go_active();
-                after.complete(true, ec);
-            }, comp.completion_handler);
 
             //boost::asio::async_completion<std::decay_t<Callback>, void(error_code)> comp{std::forward<Callback>(done)};
-            auto on_sock_conn = build_then<error_code, boost::asio::ip::tcp::endpoint>([me, resource](auto act, auto ec, auto ep){
+            auto on_sock_conn = [me, resource](auto act, auto ec, auto ep){
                 if (ec) {
-                    std::move(act).complete(true, ec);
+                    std::invoke(std::move(act), ec);
                 } else {
-                    me->on_connect(ec, ep, resource, [act = std::move(act)](auto ec) mutable { std::move(act).complete_now(ec); });
+                    me->on_connect(ec, ep, resource, [me, act = std::move(act)](auto ec) mutable { 
+                            me->go_active();
+                            std::invoke(std::move(act), ec);
+                            });
                 }
-            }, std::move(on_conn));
+            };
                 // Set the timeout for the operation
-            return m_ws.get_lowest_layer([me, this, on_sock_conn = std::move(on_sock_conn), &target, &comp, resource](auto& sock) mutable {
+            return m_ws.get_lowest_layer([me, this, on_sock_conn = std::move(on_sock_conn), &target, resource, done = std::forward<Callback>(done)](auto& sock) mutable {
                     sock.expires_after(std::chrono::seconds(30));
 
                     // Make the connection on the IP address we get from a lookup
-                    sock.async_connect(
-                        target, std::move(on_sock_conn));
-                    return comp.result.get();
+                    auto act = [target, on_sock_conn, &sock](auto done) mutable {
+                        sock.async_connect(target, [on_sock_conn, done = std::move(done)](auto ec, auto ep)mutable{on_sock_conn(std::move(done), ec, ep);});
+                    };
+                    return boost::asio::async_initiate<Callback, void(error_code)>(std::move(act), done);
                 });
         }
 

--- a/lib/malloy/core/websocket/stream.hpp
+++ b/lib/malloy/core/websocket/stream.hpp
@@ -172,9 +172,9 @@ namespace malloy::websocket
          * @endcode
          */
 		template<typename Func>
-		void get_lowest_layer(Func&& visitor)
+		auto get_lowest_layer(Func&& visitor)
 		{
-			std::visit([visitor = std::forward<Func>(visitor)](auto& s) mutable { visitor(boost::beast::get_lowest_layer(s)); }, m_underlying_conn);
+			return std::visit([visitor = std::forward<Func>(visitor)](auto& s) mutable { return visitor(boost::beast::get_lowest_layer(s)); }, m_underlying_conn);
 		}
 
         /**

--- a/lib/malloy/target_setup.cmake
+++ b/lib/malloy/target_setup.cmake
@@ -29,6 +29,7 @@ function(malloy_target_common_setup TARGET)
                 -Wextra 
                 -Wpedantic 
                 -Werror
+                -fdiagnostics-color=always
             )
     endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,8 @@ target_link_libraries(
         malloy-server
 )
 
+target_compile_definitions(${TARGET} PRIVATE MALLOY_TESTS_ENABLE_CORO=${MALLOY_BUILD_CORO_TESTS})
+
 ###
 # CTest
 ###

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -47,10 +47,12 @@ namespace malloy::test
         REQUIRE(c_ctrl.init(cli_cfg));
 
         setup_server(s_ctrl);
-        setup_client(c_ctrl);
 
         REQUIRE(s_ctrl.start());
-        CHECK(c_ctrl.run());
+
+        CHECK(c_ctrl.start());
+
+        setup_client(c_ctrl);
         c_ctrl.stop().get();
     }
 }

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -23,7 +23,7 @@
 namespace malloy::test
 {
 
-#ifdef BOOST_ASIO_HAS_CO_AWAIT
+#if MALLOY_TESTS_ENABLE_CORO
     using boost::asio::awaitable;
 
     inline void roundtrip_coro(

--- a/test/test_suites/components/controller.cpp
+++ b/test/test_suites/components/controller.cpp
@@ -36,9 +36,7 @@ TEST_SUITE("controller - roundtrips") {
             port,
             "/"
         };
-        auto stop_tkn = cli_ctrl.http_request(req, [&](auto&& resp){
-            CHECK(resp[malloy::http::field::server] == serve_agent_str);
-        });
+        auto stop_tkn = cli_ctrl.http_request(req, boost::asio::use_future);
 
         ms::controller serve_ctrl;
 
@@ -52,7 +50,8 @@ TEST_SUITE("controller - roundtrips") {
         REQUIRE(serve_ctrl.start());
         REQUIRE(cli_ctrl.run());
 
-        CHECK(!stop_tkn.get());
+        auto resp = stop_tkn.get();
+        CHECK(resp[malloy::http::field::server] == serve_agent_str);
 
     }
 }

--- a/test/test_suites/components/router.cpp
+++ b/test/test_suites/components/router.cpp
@@ -11,7 +11,8 @@ TEST_SUITE("components - router")
         constexpr auto port = 44173;
         malloy::test::roundtrip(port, [&, port](auto& c_ctrl){
                 request<> req{method::get, "127.0.0.1", port, "/"};
-                auto st = c_ctrl.http_request(req, [](const auto& resp){
+                c_ctrl.http_request(req, [](auto ec, const auto& resp){
+                    REQUIRE(!ec);
                     CHECK(resp.result() == status::unauthorized);
                 });
 

--- a/test/test_suites/components/websockets.cpp
+++ b/test/test_suites/components/websockets.cpp
@@ -11,7 +11,7 @@
 #include <boost/asio/use_awaitable.hpp>
 #include <boost/asio/use_future.hpp>
 
-#ifdef BOOST_ASIO_HAS_CO_AWAIT
+#if MALLOY_TESTS_ENABLE_CORO
 using boost::asio::awaitable;
 #endif
 
@@ -27,7 +27,7 @@ namespace
 	constexpr auto server_msg = "Hello from server";
 	constexpr auto cli_msg = "Hello from client";
 
-#ifdef BOOST_ASIO_HAS_CO_AWAIT
+#if MALLOY_TESTS_ENABLE_CORO
     template<bool BinaryMode>
     awaitable<void> client_ws_handler_coro(
         malloy::error_code ec,
@@ -248,7 +248,7 @@ TEST_SUITE("websockets")
         }
 #endif
 
-#ifdef BOOST_ASIO_HAS_CO_AWAIT
+#if MALLOY_TESTS_ENABLE_CORO
         SUBCASE("ws_connect coroutines") {
             malloy::test::roundtrip_coro(port, [](auto& ctrl) -> awaitable<void>{
                     auto v = co_await ctrl.ws_connect("127.0.0.1", port, "/", boost::asio::use_awaitable);


### PR DESCRIPTION
This implements support for the asio CompletionToken api as discussed in #74.

There are some issues currently with coroutines. The only compiler I can get working with them currently is gcc and it won't compile one of the tests (it crashes with an ICE). There is an example using coroutines, but it throws a `bad_alloc` exception with an unreadable stack trace, I'm not sure if this is an issue with how I wrote the example or asio.

## Major breaking changes

- `client::controller::http_connect` no longer accepts a visitor, instead if the filter has a single body type it accepts a completion token for a response with that body, otherwise a completion token with a variant of responses over the possible bodies. This means that code currently using callbacks and filters with more than 1 body (i.e. a custom one, none of the ones packaged with malloy currently use this) need to add a call to `std::visit`
- `client::controller::http_connect` no longer returns a `std::future<error_code>`, instead it is contained in the completion token. This means every user currently using a callback token (all of them) needs to add another argument. The reason it originally returned a future was to prevent the user having to write the same boilerplate every time to wait on the result without running off the end of `main` and without waiting forever on an error. However, the future behavior can be restored by passing `asio::use_future` and then adding a `try...catch` around the `.get()`, which is what I have done for the examples

## Other major changes

- `websocket::connection::[accept, send, read, connect]` now use CompletionToken for the template type, allowing one to pass for example `asio::use_future` and have the return be a future rather than invoking a callback

## Notable internal changes

- `action_queue` now uses a custom `action` polymorphic interface for the stored actions. This is in order to allow non-copyable `CompletionToken`s as converting to `std::function` causes a copy (as I discovered). While this does require the explicit allocation of a `unique_ptr` I believe it actually results in fewer allocations overall as `std::function` has a lot of hidden ones. This does mean `websocket::connection` has some additional boilerplate but I consider this a reasonable tradeoff for the api it now provides
- `asio::async_initiate` is now used to enable the CompletionToken api. One gotcha with it is that the type passed to the handler function is _not_ the same as the CompletionToken type, and is not guaranteed to by copyable (although it is always moveable)
- `client::http::connection` has changed a bit, `run` has been removed with its arguments being moved to the constructor. `start` is now called to start it. I originally tried to remove it completely but due to `shared_from_this` it can only be started _after_ the call to `make_shared` is complete. Honestly I am not particularly happy with `connection` in its current form, as it isn't really a standalone class and is essentially just a complex delegate that should be an implementation detail of `controller` imo (unlike `websocket::connection` for example, which is completely usable standalone).

## Things that could use improvement (IMO)

- Should `controller::stop` also use this api? It might be doable but is more complex because of the weird inheritance stuff going on with it
- Not sure if there should be variants of the tests for `use_future`, there is one currently for websockets but I'm not sure if there is any advantage to more (and the disadvantage is effectively duplicate code with only minor differences)
