### PR TITLE
fix: endpoint tests build

### DIFF
--- a/test/mocks.hpp
+++ b/test/mocks.hpp
@@ -35,7 +35,8 @@ namespace malloy::mock::http
             template<typename Body, std::invocable<malloy::http::request<Body>&&> Callback>
             void body(Callback&& done)
             {
-                return done(malloy::http::request<Body>{header_});
+                malloy::http::request<Body> req{boost::beast::http::request<Body>{header_}};
+                done(std::move(req));
             }
         };
     };

--- a/test/test_suites/components/CMakeLists.txt
+++ b/test/test_suites/components/CMakeLists.txt
@@ -4,7 +4,7 @@ target_sources(
         http_generator.cpp
         response.cpp
         router.cpp
-        #endpoints.cpp
+        endpoints.cpp
         html_multipart_parser.cpp
         request.cpp
         websockets.cpp


### PR DESCRIPTION
fixes: #93 

Turns out `beast::http::request<...>` does actually have a constructor taking just the header. I am unsure as to why this wasn't being used but I'm guessing that's part of the reason as to why the code just stopped compiling. In any case, this fix just explicitly calls that constructor before passing it on to the malloy wrapper.

Also I removed the `return` since its kind of misleading (as the function returns void)