### PR TITLE
fix: router needing server string in ctor

### DIFF
--- a/lib/malloy/server/routing/router.cpp
+++ b/lib/malloy/server/routing/router.cpp
@@ -67,9 +67,8 @@ bool router::add_subrouter(std::string resource, std::shared_ptr<router> sub_rou
     if (m_logger)
         sub_router->set_logger(m_logger->clone(m_logger->name() + " | " + resource));
 
-    if (!sub_router->server_string() && m_server_str) {
+    if (!sub_router->server_string() && m_server_str)
         sub_router->set_server_string(*m_server_str);
-    }
 
     // Add router
     try {
@@ -83,9 +82,8 @@ bool router::add_subrouter(std::string resource, std::shared_ptr<router> sub_rou
 void router::set_server_string(const std::string& str) {
     m_server_str.emplace(str);
     for (const auto&[_, sub] : m_sub_routers) {
-        if (!sub->server_string()) {
+        if (!sub->server_string())
             sub->set_server_string(str);
-        }
     }
 }
 

--- a/lib/malloy/server/routing/router.cpp
+++ b/lib/malloy/server/routing/router.cpp
@@ -7,7 +7,7 @@
 
 using namespace malloy::server;
 
-router::router(std::shared_ptr<spdlog::logger> logger, std::string server_str) :
+router::router(std::shared_ptr<spdlog::logger> logger, std::optional<std::string> server_str) :
     m_logger(std::move(logger)), m_server_str{std::move(server_str)}
 {
 }
@@ -67,6 +67,10 @@ bool router::add_subrouter(std::string resource, std::shared_ptr<router> sub_rou
     if (m_logger)
         sub_router->set_logger(m_logger->clone(m_logger->name() + " | " + resource));
 
+    if (!sub_router->server_string() && m_server_str) {
+        sub_router->set_server_string(*m_server_str);
+    }
+
     // Add router
     try {
         m_sub_routers.try_emplace(std::move(resource), std::move(sub_router));
@@ -75,6 +79,14 @@ bool router::add_subrouter(std::string resource, std::shared_ptr<router> sub_rou
     }
 
     return true;
+}
+void router::set_server_string(const std::string& str) {
+    m_server_str.emplace(str);
+    for (const auto&[_, sub] : m_sub_routers) {
+        if (!sub->server_string()) {
+            sub->set_server_string(str);
+        }
+    }
 }
 
 bool router::add_preflight(const std::string_view target, http::preflight_config cfg)


### PR DESCRIPTION
fixes: #68 

This implements part of what I suggested in the issue while keeping the current behavior and features (namely different server string for subrouters). I'm not sure this is really desired functionality but since this is a fix I didn't want to remove functionality.

The router server string is now an optional argument of the ctor, if it is not specified then it is set by `add_subrouter`. This works because for a router to actually be used it is guaranteed to either be the root router, whose server string is set by the `controller` or as a subrouter that will eventually be added to root. This of course requires that it composes commutativity (i.e. the order of adding subrouter trees to the root doesn't matter), which I've added a test case for.

There are some drawbacks to this approach, the biggest of which is I think the lack of ability to change the string after construction. I made the setter private because I think the propagation is an implementation detail, and it would be weird to have the propagation just stop. One solution could be to remove the ability to preserve different server strings on subrouters and simply overwrite it rather than checking whether it has been set yet, which I like but removes the feature of different server strings per subrouter.