### PR TITLE
#130 Make server::router not move-able.

### DIFF
--- a/lib/malloy/server/routing/router.cpp
+++ b/lib/malloy/server/routing/router.cpp
@@ -92,12 +92,6 @@ router::add_subrouter(std::string resource, std::unique_ptr<router> sub_router)
     return true;
 }
 
-bool
-router::add_subrouter(std::string resource, router&& sub)
-{
-    return add_subrouter(std::move(resource), std::make_unique<router>(std::move(sub)));
-}
-
 void
 router::set_server_string(std::string_view str)
 {

--- a/lib/malloy/server/routing/router.hpp
+++ b/lib/malloy/server/routing/router.hpp
@@ -240,7 +240,7 @@ namespace malloy::server
         /**
          * Move constructor.
          */
-        router(router&& other) noexcept = default;
+        router(router&& other) noexcept = delete;
 
         /**
          * Destructor.
@@ -263,7 +263,7 @@ namespace malloy::server
          * @return A reference to the assignee.
          */
         router&
-        operator=(router&& rhs) noexcept = default;
+        operator=(router&& rhs) noexcept = delete;
 
         /**
          * Set the logger to use.
@@ -282,12 +282,6 @@ namespace malloy::server
          */
         bool
         add_subrouter(std::string resource, std::unique_ptr<router> sub_router);
-
-        /**
-         * @copydoc add_subrouter
-         */
-        bool
-        add_subrouter(std::string resource, router&& sub_router);
 
         /**
          * Add an HTTP regex endpoint.

--- a/lib/malloy/server/routing_context.cpp
+++ b/lib/malloy/server/routing_context.cpp
@@ -14,7 +14,8 @@ using namespace malloy::server;
 
 routing_context::routing_context(config cfg) :
     m_cfg{std::move(cfg)},
-    m_router{m_cfg.logger != nullptr ? m_cfg.logger->clone("router") : nullptr, m_cfg.agent_string}
+    m_router{new server::router{m_cfg.logger != nullptr ? m_cfg.logger->clone("router") : nullptr,
+                                m_cfg.agent_string}}
 {
     m_cfg.validate();
 

--- a/lib/malloy/server/routing_context.hpp
+++ b/lib/malloy/server/routing_context.hpp
@@ -107,11 +107,10 @@ namespace malloy::server
          * @return The top-level router.
          */
         [[nodiscard]]
-        constexpr
         const malloy::server::router&
         router() const noexcept
         {
-            return m_router;
+            return *m_router;
         }
 
         /**
@@ -120,16 +119,15 @@ namespace malloy::server
          * @return The top-level router.
          */
         [[nodiscard]]
-        constexpr
         malloy::server::router&
         router() noexcept
         {
-            return m_router;
+            return *m_router;
         }
 
     private:
         config m_cfg;
-        malloy::server::router m_router;
+        std::unique_ptr<malloy::server::router> m_router;
         #if MALLOY_FEATURE_TLS
             std::unique_ptr<boost::asio::ssl::context> m_tls_ctx;
         #endif
@@ -154,7 +152,7 @@ namespace malloy::server
                 nullptr,
 #endif
                 boost::asio::ip::tcp::endpoint{boost::asio::ip::make_address(ctrl.m_cfg.interface), ctrl.m_cfg.port},
-                std::make_shared<class router>(std::move(ctrl.m_router)),
+                std::move(ctrl.m_router),
                 std::make_shared<std::filesystem::path>(ctrl.m_cfg.doc_root),
                 ctrl.m_cfg.agent_string);
 


### PR DESCRIPTION
# Issue

As explained in #130. With this change I no longer see the crash I was seeing.

# Commit Message

```txt
Routes added to the router have a raw reference to the router itself.
When a router is moved, even though all the members are moved, the
raw references would not update themselves, which makes them dangling.

Downgrade router from move-able to non-move-able, and make
routing_context store a unique_ptr to router instead of an object.
This way, moving the routing_context would not end up creating a
new router, so references stored in the routes would remain valid.
```